### PR TITLE
[WIP] Implement normalize.css 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "get-stdin": "^6.0.0",
+    "normalize.css": "^8.0.0",
     "sass-extract": "^2.1.0"
   }
 }


### PR DESCRIPTION
Reduce inconsistencies across browsers and improve css development by normalizing styles in the user agent stylesheet across browsers. PrinceXML also applies a default stylesheet and normalize.css should catch most if not all default styles. For PrinceXML styles that are unique, a file has been created to manually place those resets.
**_Note_**: This is for Baked PDF. We should investigate implementing this in webview as well

[A good explanation on why we're doing this](http://meyerweb.com/eric/thoughts/2007/04/18/reset-reasoning/)

Compared [normalize.css](https://github.com/necolas/normalize.css/) and [reset-css](https://github.com/shannonmoeller/reset-css). Both are NPM packages that aim to achive the same goal.

## normalize.css
- suite of tests
- retains many useful default browser styles (you don’t have to redeclare styles for all the common typographic elements)
- fixes common desktop and mobile browser bugs that are out of scope for resets
- extensive inline documentation

## reset-css
- an *almost* unmodifed copy of https://meyerweb.com/eric/tools/css/reset/
- removes the boldfacing from headings and strong elements; un-italicizes em and cite elements (content that specifically uses these tags  from the CM's will have to be styled manually)
- heading tags sizing is not always consitent across browsers so it is also reset
- can import via NPM, SASS, or LESS
- Clutters debugging tools with a large inheritence chain 

**Decided to use `normalize.css` over `reset.css` becuase of wider use, greater support, more frequent updates, thorugh documentation, and a system of tests.**

***Note*** In Eric Meyer's explanation, its cited that the propery `inherit` does not work in IE but this post was writtern in 2007 and the property does currently work in IE 8 (desktop) and 12 (mobile) https://developer.mozilla.org/en-US/docs/Web/CSS/inherit
