### PR TITLE
Add dot after number in references

### DIFF
--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -393,7 +393,7 @@
     .reference::before {
       container: span;
       class: os-reference-number;
-      content: counter($citationCounter) ".";
+      content: counter($citationCounter) ". ";
     }
   }
 }

--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -393,7 +393,7 @@
     .reference::before {
       container: span;
       class: os-reference-number;
-      content: counter($citationCounter);
+      content: counter($citationCounter) ".";
     }
   }
 }

--- a/recipes/output/american-government.css
+++ b/recipes/output/american-government.css
@@ -908,7 +908,7 @@
 :pass(3) [data-type="cite"] .reference::before {
   container: span;
   class: os-reference-number;
-  content: counter(citation); }
+  content: counter(citation) "."; }
 
 :pass(3) body {
   counter-reset: term; }

--- a/recipes/output/american-government.css
+++ b/recipes/output/american-government.css
@@ -908,7 +908,7 @@
 :pass(3) [data-type="cite"] .reference::before {
   container: span;
   class: os-reference-number;
-  content: counter(citation) "."; }
+  content: counter(citation) ". "; }
 
 :pass(3) body {
   counter-reset: term; }

--- a/recipes/output/intro-business.css
+++ b/recipes/output/intro-business.css
@@ -1228,7 +1228,7 @@
 :pass(3) [data-type="cite"] .reference::before {
   container: span;
   class: os-reference-number;
-  content: counter(citation); }
+  content: counter(citation) "."; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: example; }

--- a/recipes/output/intro-business.css
+++ b/recipes/output/intro-business.css
@@ -1228,7 +1228,7 @@
 :pass(3) [data-type="cite"] .reference::before {
   container: span;
   class: os-reference-number;
-  content: counter(citation) "."; }
+  content: counter(citation) ". "; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: example; }

--- a/recipes/output/principles-management.css
+++ b/recipes/output/principles-management.css
@@ -1294,7 +1294,7 @@
 :pass(3) [data-type="cite"] .reference::before {
   container: span;
   class: os-reference-number;
-  content: counter(citation) "."; }
+  content: counter(citation) ". "; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: example; }

--- a/recipes/output/principles-management.css
+++ b/recipes/output/principles-management.css
@@ -1294,7 +1294,7 @@
 :pass(3) [data-type="cite"] .reference::before {
   container: span;
   class: os-reference-number;
-  content: counter(citation); }
+  content: counter(citation) "."; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: example; }


### PR DESCRIPTION
I've added dot after number in the _References_ module. This problem is related to this issue https://github.com/openstax/webview/issues/2155 and part of the solution needs to be done in webview repo (https://github.com/openstax/webview/pull/2156).