### PR TITLE
Remove brackets for glossary and index

### DIFF
--- a/recipes/mixins/_compose.scss
+++ b/recipes/mixins/_compose.scss
@@ -97,7 +97,7 @@
       $clusterBy: map-get($page, clusterBy);
       @include validate_enum($clusterBy, $CLUSTER__PREFIX__);
 
-      $keyName: if($specialPageType == $PAGE_GLOSSARY, '<glossary>', '.#{$className}');
+      $keyName: if($specialPageType == $PAGE_GLOSSARY, 'glossary', '.#{$className}');
       $sourceSelector: if($specialPageType == $PAGE_GLOSSARY, 'div[data-type="#{$className}"] dl', 'section.#{$className}');
       @if ($specialPageType == $PAGE_GLOSSARY) {
         div[data-type="#{$className}"] {
@@ -218,11 +218,11 @@
     $className: map-get($page, className);
     $childPages: map-get($page, childPages);
     $specialPageType: map-get($page, specialPageType);
-    $keyName: if($specialPageType == $PAGE_GLOSSARY, '<glossary>', '.#{$className}');
+    $keyName: if($specialPageType == $PAGE_GLOSSARY, 'glossary', '.#{$className}');
 
     @include validate_type($childPages, list);
     @include validate_enumOptional($specialPageType, $PAGE__PREFIX__);
-    
+
     @include _processComposites($childPages);
   }
 }
@@ -234,7 +234,7 @@
     @include validate_type($childPages, list);
     @include validate_enumOptional($specialPageType, $PAGE__PREFIX__);
 
-    $keyName: if($specialPageType == $PAGE_GLOSSARY, '<glossary>', '.#{$className}');
+    $keyName: if($specialPageType == $PAGE_GLOSSARY, 'glossary', '.#{$className}');
     @each $childPage in $childPages {
       $childclassName: map-get($childPage, className);
       [data-type="chapter"] {
@@ -308,7 +308,7 @@
       $sourceSelector: if($specialPageType == $PAGE_CITATIONS, '[data-type="note"].#{$className}', 'section.#{$className}');
       $clusterBy: map-get($page, clusterBy);
       $chapterPages: map-get($page, chapterPages);
-      $keyName: if($specialPageType == $PAGE_GLOSSARY, '<glossary>', '.#{$className}');
+      $keyName: if($specialPageType == $PAGE_GLOSSARY, 'glossary', '.#{$className}');
 
       // Validate
       @include validate_typeOptional($chapterPages, bool);
@@ -378,7 +378,7 @@
     @include validate_enum($clusterBy, $CLUSTER__PREFIX__);
 
 
-    $keyName: if($specialPageType == $PAGE_INDEX, '<index>', '.#{$className}');
+    $keyName: if($specialPageType == $PAGE_INDEX, 'index', '.#{$className}');
 
     &::after {
       container: div;

--- a/recipes/output/accounting.css
+++ b/recipes/output/accounting.css
@@ -1108,7 +1108,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {

--- a/recipes/output/american-government.css
+++ b/recipes/output/american-government.css
@@ -953,7 +953,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1219,7 +1219,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -1544,7 +1544,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1759,7 +1759,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -690,7 +690,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -960,7 +960,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/astronomy.css
+++ b/recipes/output/astronomy.css
@@ -1027,7 +1027,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1289,7 +1289,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/biology.css
+++ b/recipes/output/biology.css
@@ -1061,7 +1061,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1255,7 +1255,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/business-ethics.css
+++ b/recipes/output/business-ethics.css
@@ -920,7 +920,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1155,7 +1155,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/chemistry.css
+++ b/recipes/output/chemistry.css
@@ -985,7 +985,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1210,7 +1210,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/dev-math.css
+++ b/recipes/output/dev-math.css
@@ -1092,7 +1092,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1377,7 +1377,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/economics.css
+++ b/recipes/output/economics.css
@@ -890,7 +890,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1154,7 +1154,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/entrepreneurship.css
+++ b/recipes/output/entrepreneurship.css
@@ -1243,7 +1243,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/intro-business.css
+++ b/recipes/output/intro-business.css
@@ -1337,7 +1337,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1554,7 +1554,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(8) body::after {

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -645,7 +645,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -840,7 +840,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/principles-management.css
+++ b/recipes/output/principles-management.css
@@ -1403,7 +1403,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>"; }
+    data-uuid-key: "glossary"; }
 
 :pass(3) div[data-type="chapter"] {
   string-set: chap-id attr(id); }
@@ -1614,7 +1614,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/psychology.css
+++ b/recipes/output/psychology.css
@@ -942,7 +942,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1162,7 +1162,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/sociology.css
+++ b/recipes/output/sociology.css
@@ -876,7 +876,7 @@
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1138,7 +1138,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/statistics.css
+++ b/recipes/output/statistics.css
@@ -1015,7 +1015,7 @@ Formula Review page
     content: pending(glossary-TOCOMPOSITE);
     class: "os-eoc os-glossary-container";
     data-type: "composite-page";
-    data-uuid-key: "<glossary>";
+    data-uuid-key: "glossary";
     sort-by: xhtml|dl > xhtml|dt, nocase; }
 
 :pass(3) div[data-type="chapter"] {
@@ -1265,7 +1265,7 @@ Formula Review page
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -1424,7 +1424,7 @@
   content: pending(index-TOCOMPOSITE);
   class: "os-eob os-index-container";
   data-type: "composite-page";
-  data-uuid-key: "<index>";
+  data-uuid-key: "index";
   group-by: span, "span::attr(group-by)", nocase; }
 
 :pass(9) .os-index-container > div.group-by:first-of-type > span.group-label:match("^[ ](Symbols|SYMBOLS)") {


### PR DESCRIPTION
The `<` breaks with the fixes made for the crit-sit because it is now escaped. 