### PR TITLE
Allow npm in scripts

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -209,7 +209,9 @@ if [[ ! ${BOOTSTRAP_ALREADY_RAN} ]]; then
 
   # ensure yarn is installed (for installing JS packages)
   if [[ -f "./package.json" ]]; then
-    [[ $(command -v yarn) ]] || die "Install yarn by going to https://yarnpkg.com or adding it to Brewfile (macos)"
+    [[ $(command -v yarn) ]] || \
+      [[ $(command -v npm) ]] || \
+        die "yarn or npm must be installed"
   fi
 
   # Note: Skip rbenv for Travis because it already has ruby

--- a/script/setup
+++ b/script/setup
@@ -7,7 +7,9 @@ source ./script/bootstrap || exit 111
 # JavaScript stuff
 if [[ -f "./package.json" ]]; then
   do_progress_quiet "Installing JavaScript Packages" \
-    yarn --prefer-offline
+    # Prefer yarn but allow npm
+    [[ $(command -v yarn) ]] && yarn --prefer-offline || \
+      [[ $(command -v npm) ]] && npm install
 fi
 
 # Python stuff

--- a/script/update
+++ b/script/update
@@ -7,4 +7,6 @@ do_progress_quiet 'Reinstalling python packages' \
 
  # Use --force so that the packages are reinstalled
 do_progress_quiet "Reinstalling NodeJS package.json" \
-  yarn install --prefer-offline --force
+  rm ./../node_modules || die "No JS modules installed"
+  [[ $(command -v yarn) ]] && yarn install --prefer-offline || \
+    [[ $(command -v npm) ]] && npm install

--- a/script/update
+++ b/script/update
@@ -7,6 +7,6 @@ do_progress_quiet 'Reinstalling python packages' \
 
  # Use --force so that the packages are reinstalled
 do_progress_quiet "Reinstalling NodeJS package.json" \
-  rm ./../node_modules || die "No JS modules installed"
+  rm -r ./../node_modules || die "No JS modules installed"
   [[ $(command -v yarn) ]] && yarn install --prefer-offline || \
     [[ $(command -v npm) ]] && npm install


### PR DESCRIPTION
Scripts currently error whenever yarn is not installed even though npm should be able to handle the job just fine