### PR TITLE
Issue #818, print missing feature name

### DIFF
--- a/recipes/books/_feature.scss
+++ b/recipes/books/_feature.scss
@@ -1,6 +1,6 @@
 @function feature-enabled($feature_name) {
   @if not map-has-key($FEATURES, $feature_name) {
-    @error "This feature has been removed or applied to all recipes";
+    @error "The feature `#{$feature_name}` has been removed or applied to all recipes";
   }
   @return map-get($FEATURES, $feature_name);
 }


### PR DESCRIPTION
When a release/feature flag is not found, put the name in the error message. Link: Issue #818