### PR TITLE
change a:link to a[href]

### DIFF
--- a/styles/framework/base.scss
+++ b/styles/framework/base.scss
@@ -22,7 +22,7 @@ body {
   //vs line-height: line-height(0); vs $base-line-height???
 }
 
-a:link {
+a[href] {
   @include link-style(color-map(bodyLink));
 }
 

--- a/styles/framework/import-style.scss
+++ b/styles/framework/import-style.scss
@@ -20,7 +20,7 @@ body {
   //vs line-height: line-height(0); vs $base-line-height???
 }
 
-a:link {
+a[href] {
   @include link-style(color-map(bodyLink));
 }
 

--- a/styles/framework/mixins/_notes.scss
+++ b/styles/framework/mixins/_notes.scss
@@ -25,10 +25,8 @@
     fill: color-map(featureBodyText) !important; //this is necessary to override the inline svg fill
   }
 
-  a {
-    &:link {
-      @include link-style(settings(note-link));
-    }
+  a[href] {
+    @include link-style(settings(note-link));
   }
   .os-note-body {
     @include noteBody($bgColor, $bodyFontColor, $borderColor);

--- a/styles/output/intro-business-2.css
+++ b/styles/output/intro-business-2.css
@@ -245,7 +245,7 @@ body {
   font-family: "Noto Sans", sans-serif;
   line-height: 15px; }
 
-a:link {
+a[href] {
   color: #027EB5;
   text-decoration: none;
   border-bottom: #027EB5 solid 0.02em; }

--- a/styles/output/intro-business.css
+++ b/styles/output/intro-business.css
@@ -278,7 +278,7 @@ body {
   font-family: "Noto Sans", sans-serif;
   line-height: 15px; }
 
-a:link {
+a[href] {
   color: #027EB5;
   text-decoration: none;
   border-bottom: #027EB5 solid 0.02em; }
@@ -825,7 +825,7 @@ div.note div.table table thead tr:first-of-type th {
   border-top-left-radius: 3px; }
   [data-type="note"].exploring-business-careers svg text {
     fill: #000000 !important; }
-  [data-type="note"].exploring-business-careers a:link {
+  [data-type="note"].exploring-business-careers a[href] {
     color: #0064A0;
     text-decoration: none;
     border-bottom: #0064A0 solid 0.02em; }
@@ -882,7 +882,7 @@ div.note div.table table thead tr:first-of-type th {
   margin-bottom: 12px; }
   [data-type="note"].managing-change svg text {
     fill: #000000 !important; }
-  [data-type="note"].managing-change a:link {
+  [data-type="note"].managing-change a[href] {
     color: #0064A0;
     text-decoration: none;
     border-bottom: #0064A0 solid 0.02em; }
@@ -939,7 +939,7 @@ div.note div.table table thead tr:first-of-type th {
   margin-bottom: 12px; }
   [data-type="note"].link-to-learning svg text {
     fill: #000000 !important; }
-  [data-type="note"].link-to-learning a:link {
+  [data-type="note"].link-to-learning a[href] {
     color: #0064A0;
     text-decoration: none;
     border-bottom: #0064A0 solid 0.02em; }
@@ -996,7 +996,7 @@ div.note div.table table thead tr:first-of-type th {
   margin-bottom: 12px; }
   [data-type="note"].catching-spirit svg text {
     fill: #000000 !important; }
-  [data-type="note"].catching-spirit a:link {
+  [data-type="note"].catching-spirit a[href] {
     color: #0064A0;
     text-decoration: none;
     border-bottom: #0064A0 solid 0.02em; }
@@ -1053,7 +1053,7 @@ div.note div.table table thead tr:first-of-type th {
   margin-bottom: 12px; }
   [data-type="note"].concept-check svg text {
     fill: #000000 !important; }
-  [data-type="note"].concept-check a:link {
+  [data-type="note"].concept-check a[href] {
     color: #0064A0;
     text-decoration: none;
     border-bottom: #0064A0 solid 0.02em; }
@@ -1110,7 +1110,7 @@ div.note div.table table thead tr:first-of-type th {
   margin-bottom: 12px; }
   [data-type="note"].expanding-around-globe svg text {
     fill: #000000 !important; }
-  [data-type="note"].expanding-around-globe a:link {
+  [data-type="note"].expanding-around-globe a[href] {
     color: #0064A0;
     text-decoration: none;
     border-bottom: #0064A0 solid 0.02em; }
@@ -1167,7 +1167,7 @@ div.note div.table table thead tr:first-of-type th {
   margin-bottom: 12px; }
   [data-type="note"].ethics-in-practice svg text {
     fill: #000000 !important; }
-  [data-type="note"].ethics-in-practice a:link {
+  [data-type="note"].ethics-in-practice a[href] {
     color: #0064A0;
     text-decoration: none;
     border-bottom: #0064A0 solid 0.02em; }
@@ -1224,7 +1224,7 @@ div.note div.table table thead tr:first-of-type th {
   margin-bottom: 12px; }
   [data-type="note"].customer-satisfaction svg text {
     fill: #000000 !important; }
-  [data-type="note"].customer-satisfaction a:link {
+  [data-type="note"].customer-satisfaction a[href] {
     color: #0064A0;
     text-decoration: none;
     border-bottom: #0064A0 solid 0.02em; }

--- a/styles/themes/theme1/mixins/_notes.scss
+++ b/styles/themes/theme1/mixins/_notes.scss
@@ -76,7 +76,7 @@
     border: 0;
   }
 
-  a:link {
+  a[href] {
     //@mixin link-style($body-link-color);
   }
 }

--- a/styles/themes/theme1/parts/eoc.scss
+++ b/styles/themes/theme1/parts/eoc.scss
@@ -65,7 +65,7 @@
    * ------------------------
    */
   section {
-    .title a:link {
+    .title a[href] {
       //.font-scale(0);
       @include link-no-border-style ($eoc-subtitles-color); //overriding .link-style
       border-bottom: none;

--- a/styles/themes/theme1/parts/notes.scss
+++ b/styles/themes/theme1/parts/notes.scss
@@ -6,7 +6,7 @@
   width: 100%;
   box-decoration-break: slice;
   box-sizing: border-box;
-  a:link {
+  a[href] {
     @include link-style ($note-link-color);
   }
   > div.title {

--- a/styles/themes/theme1/theme.scss
+++ b/styles/themes/theme1/theme.scss
@@ -72,14 +72,14 @@ html {
  * Global Styles
  * ------------------------
  */
-.appendix:not(.toc-appendix) a:link,
-.chapter.section a:link,
-.preface:not(.toc-preface) a:link {
+.appendix:not(.toc-appendix) a[href],
+.chapter.section a[href],
+.preface:not(.toc-preface) a[href] {
   @include link-style($body-link-color);
 }
 
-.colophon a:link,
-.index a:link {
+.colophon a[href],
+.index a[href] {
   @include link-no-border-style($body-link-color);
 }
 
@@ -118,9 +118,9 @@ span.colored-text {
   color: $colored-text-color;
 }
 
-.appendix.module a:link.target-section,
-.chapter.cnx-eoc a:link.target-section,
-.chapter.section.module a:link.target-section {
+.appendix.module a[href].target-section,
+.chapter.cnx-eoc a[href].target-section,
+.chapter.section.module a[href].target-section {
   background-image: url("ccap-astronomy/LO.svg");
   background-repeat: no-repeat;
   background-position: left;

--- a/styles/themes/theme2/parts/eoc.scss
+++ b/styles/themes/theme2/parts/eoc.scss
@@ -65,7 +65,7 @@
    * ------------------------
    */
   section {
-    .title a:link {
+    .title a[href] {
       //.font-scale(0);
       @include link-no-border-style ($eoc-subtitles-color); //overriding .link-style
       border-bottom: none;

--- a/styles/themes/theme2/parts/notes.scss
+++ b/styles/themes/theme2/parts/notes.scss
@@ -6,7 +6,7 @@
   width: 100%;
   box-decoration-break: slice;
   box-sizing: border-box;
-  a:link {
+  a[href] {
     @include link-style ($note-link-color);
   }
   > div.title {


### PR DESCRIPTION
refs #843 and  openstax/unified#167

`a:link` _only_ applies to unvisited links but I think the intent is for all links to have this styling, right? See https://developer.mozilla.org/en-US/docs/Web/CSS/:link

If that is not the case then this can be closed.