### PR TITLE
Fix cnx-recipes installation in docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 ##    docker build -t openstax/cnx-recipes:latest .
 ##
 ## To start the container:
-##    docker run --mount type=bind,source=$(pwd),target=/src -it openstax/cnx-recipes:latest /bin/bash
+##    docker run --mount type=bind,source=$(pwd),target=/code -it openstax/cnx-recipes:latest /bin/bash
 ## where the cnx-recipes repo has been cloned into the
 ## current working directory.
 ##

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -105,10 +105,9 @@ if [[ ! ${BOOTSTRAP_ALREADY_RAN} ]]; then
 
       virtualenv_dir="./venv/"
       python_version="$(< .python-version)"
-      virtualenv_command="virtualenv"
 
-      # macOS needs a little extra love
-      if [[ "$(uname -s)" = "Darwin" ]]; then
+      # Use pyenv if it is installed
+      if [[ -n "$(which pyenv)" ]]; then
         # Install the correct python version if it is not installed yet
         if [[ ! $(pyenv which python) ]]; then
           do_progress_quiet "Installing Python ${python_version} (using pyenv)" \
@@ -116,8 +115,7 @@ if [[ ! ${BOOTSTRAP_ALREADY_RAN} ]]; then
         fi
         # Ensure pyenv is initialized
         eval "$(pyenv init -)"
-
-        virtualenv_command="pyenv exec virtualenv"
+        pyenv global "${python_version}"
       fi
 
       # Install pip if it is not available
@@ -134,9 +132,9 @@ if [[ ! ${BOOTSTRAP_ALREADY_RAN} ]]; then
       fi
 
       # Install virtualenv
-      # If macOS then check that the pyenv virtualenv is installed.
-      # If not running macOS then check that some virtualenv is installed.
-      if [[ "$(uname -s)" != "Darwin" && ! $(command -v virtualenv) ]] || [[ "$(uname -s)" = "Darwin" && ! $(pyenv which virtualenv) ]]; then
+      # If pyenv is installed then check that the pyenv virtualenv is installed.
+      # If not then check that some virtualenv is installed.
+      if [[ -z "$(which pyenv)" && ! $(command -v virtualenv) ]] || [[ -n "$(which pyenv)" && ! $(pyenv which virtualenv) ]]; then
         do_progress_quiet "Installing Python virtualenv" \
           pip install virtualenv
         # Rehash so that virtualenv is available
@@ -146,7 +144,7 @@ if [[ ! ${BOOTSTRAP_ALREADY_RAN} ]]; then
       if [[ ! -d "${virtualenv_dir}" ]]; then
         # shellcheck disable=SC2086
         do_progress_quiet "Setting up a Python virtualenv" \
-          ${virtualenv_command} "${virtualenv_dir}"
+          virtualenv -p "$(which python)" "${virtualenv_dir}"
       fi
 
       do_progress_quiet "Activating Python virtualenv" \


### PR DESCRIPTION
- Fix script/bootstrap to use pyenv if installed

  The bootstrap script was checking if it's running on MacOS (if uname
  is "Darwin") before using pyenv.  The way it should probably work is if
  pyenv is installed, we should use it.
  
  `virtualenv` was already installed system wide at
  `/usr/local/bin/virtualenv` in the docker container.  So `pyenv` uses
  this to create the virtualenv dir at `./venv` which uses the system
  python 3.7.
  
  In the docker container.  `./script/bake-book` was failing because we
  installed python 2.7 using pyenv but never used it.
  This is the traceback:
  
  ```
  ==> Baking ./data/statistics-raw.xhtml using statistics (~1min)
  Traceback (most recent call last):
    File "/code/venv/bin/cnx-easybake", line 11, in <module>
      load_entry_point('cnx-easybake', 'console_scripts', 'cnx-easybake')()
    File "/code/venv/src/cnxeasybake/cnxeasybake/scripts/main.py", line 88, in main
      args.coverage_file, args.use_repeatable_ids)
    File "/code/venv/src/cnxeasybake/cnxeasybake/scripts/main.py", line 19, in easybake
      oven = Oven(css_in, use_repeatable_ids)
    File "/code/venv/src/cnxeasybake/cnxeasybake/oven.py", line 111, in __init__
      self.update_css(css_in, clear_css=True)  # clears state as well
    File "/code/venv/src/cnxeasybake/cnxeasybake/oven.py", line 164, in update_css
      rules, _ = tinycss2.parse_stylesheet_bytes(css, skip_whitespace=True)
    File "/code/venv/lib/python3.7/site-packages/tinycss2/bytes.py", line 110, in parse_stylesheet_bytes
      css_bytes, protocol_encoding, environment_encoding)
    File "/code/venv/lib/python3.7/site-packages/tinycss2/bytes.py", line 33, in decode_stylesheet_bytes
      if css_bytes.startswith(b'@charset "'):
  TypeError: startswith first arg must be str or a tuple of str, not bytes
  ./script/bake-book: ERROR: could not run [cnx-easybake --coverage-file ./data/statistics-baked.xhtml.lcov ./recipes/output/statistics.css ./data/statistics-raw.xhtml ./data/statistics-baked.xhtml]
  ```

- Fix example usage mount target dir in Dockerfile

  The cnx-recipes docker image used to put code in `/src`, so the example
  usage also mounts the current directory at `/src`.  The docker file has
  been changed to use `/code` instead, so the example usage needs to be
  updated as well.
