### PR TITLE
Add katalyst01.cnx.org as a fetch-html host

### DIFF
--- a/config/neb-config
+++ b/config/neb-config
@@ -35,3 +35,6 @@ url = https://staged.cnx.org
 
 [environ-easyvm5.cnx.org]
 url = https://easyvm5.cnx.org
+
+[environ-katalyst01.cnx.org]
+url = https://katalyst01.cnx.org


### PR DESCRIPTION
When trying to fetch a book from katalyst01
`HOST=katalyst01.cnx.org ./script/fetch-html calculus-vol1`:

```
Error: unknown environment: 'katalyst01.cnx.org'
./script/fetch-html: ERROR: could not run [neb get -d ./data/calculus-vol1/raw katalyst01.cnx.org col11964 ]
```

The reason is because neb doesn't know about "katalyst01.cnx.org".

Add katalyst01.cnx.org to neb config so neb get can fetch from
katalyst01.cnx.org.