### PR TITLE
Add script/docker-run for running scripts in containers

### DIFF
--- a/script/docker-run
+++ b/script/docker-run
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script can be used to run cnx-recipes scripts inside a docker container,
+# e.g. ./script/docker-run ./script/fetch-html statistics
+# will download statistics in ./data
+#
+# The only prerequisite for this script is that docker is installed.  This can
+# be done by running ./script/install-docker
+# There is no need to run ./script/setup etc
+
+BOOTSTRAP_ALREADY_RAN=1
+cd "$(dirname "$0")/.." || exit 111
+source ./script/bootstrap || exit 111
+
+if ! docker images | grep -q openstax/cnx-recipes; then
+  do_progress_quiet "Building the cnx-recipes image (takes ~15 minutes)" \
+    docker build -t openstax/cnx-recipes:latest .
+fi
+
+if [ ! -d ./node_modules ]; then
+  do_progress_quiet "Running ./script/setup in the container" \
+    docker run --rm -v "$(pwd)":/code openstax/cnx-recipes ./script/setup
+fi
+
+docker run --rm -v "$(pwd)":/code -ti openstax/cnx-recipes "$@"
+docker run --rm -v "$(pwd)":/code openstax/cnx-recipes chown -R "$UID" .

--- a/script/install-docker
+++ b/script/install-docker
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+BOOTSTRAP_ALREADY_RAN=1
+cd "$(dirname "$0")/.." || exit 111
+source ./script/bootstrap || exit 111
+
+if [[ -z "$(command -v docker)" ]]; then
+  if [[ -n "$(command -v apt-get)" ]]; then
+    do_progress_quiet "Installing docker" \
+      sudo apt-get install -y docker.io
+    sudo usermod -a -G docker "$USER"
+    _say "Docker installed.  You need to open a new terminal for it to work."
+  elif [[ -n "$(command -v brew)" ]]; then
+    do_progress_quiet "Installing docker" \
+      brew cask install docker
+  else
+    die "Please go to https://www.docker.com/get-started for instructions to install docker."
+  fi
+fi


### PR DESCRIPTION
This is a helper script for users who have installation issues and don't know how to use docker.
They can just do `./script/docker-run ./script/fetch-html statistics`, for example, to run `./script/fetch-html statistics` in a docker container.

This is an attempt to make cnx-recipes easier to run.  A first step.
Let me know what you guys think.

---

- Add script/install-docker for installing docker

  This script can be used for installing docker but not anything else.
  Docker can then be used to run containers which install everything else
  in cnx-recipes.

- Add script/docker-run for running scripts in containers

  Add a helper script for users to run scripts without knowing how to use
  docker.
  
  This script can be used to run cnx-recipes scripts inside a docker container,
  e.g. `./script/docker-run ./script/fetch-html statistics`
  will download statistics in `./data`
  
  The only prerequisite for this script is that docker is installed.  This can
  be done by running `./script/install-docker`
  There is no need to run `./script/setup` etc
