### PR TITLE
feat: set framework settings without creating a function

### DIFF
--- a/styles/framework/design-space/_init.scss
+++ b/styles/framework/design-space/_init.scss
@@ -196,7 +196,7 @@ $FRAMEWORK_SPACE_PLACE: ();
     $value: nth($description, 2);
     @if $value_set == enum('ValueSet:::GROUPED') {
       @if not map-has-key($groups, $value) {
-        @return error(enum('Error:::INDEX_ERROR'), "Group `#{$value}` does not exist.");
+        @return error(enum('Error:::INVALID_REFERENCE'), "Group `#{$value}` does not exist.");
       }
       @return resolve_description(map-deep-get($groups, $value), $groups);
     }
@@ -219,7 +219,10 @@ $FRAMEWORK_SPACE_PLACE: ();
         #{$selector}#{$subselector} {
           @each $ancestor_name in get_lineage($subspace_name) {
             $ancestor: get_space($ancestor_name);
-            $groups: map-deep-get($ancestor, _groups);
+            $groups: empty_map();
+            @if map-has-key($ancestor, _groups) {
+              $groups: map-deep-get($ancestor, _groups);
+            }
             $properties: get_properties($ancestor, $component_name);
             @each $property, $description in $properties {
               @if not map-has-key($root_properties, $property) {

--- a/styles/framework/enum/_error.scss
+++ b/styles/framework/enum/_error.scss
@@ -1,4 +1,5 @@
 @include create_enum_type("Error",
+  "INVALID_REFERENCE",
   "INDEX_ERROR",
   "TYPE_ERROR"
 );

--- a/styles/framework/function/_map-key-prefix-flatten.scss
+++ b/styles/framework/function/_map-key-prefix-flatten.scss
@@ -1,8 +1,8 @@
-@function map_key_prefix_flatten($map, $prefix: "") {
+@function map_key_prefix_flatten($map, $prefix: "", $flatten_exclude_key: "") {
   $flattened: empty_map();
   @each $key, $value in $map {
-    @if type-of($value) == "map" and not map-get($value, '_ref') {
-      $flattened: map-merge($flattened, map_key_prefix_flatten($value, "#{$prefix}#{$key}:::"))
+    @if type-of($value) == "map" and not map-get($value, $flatten_exclude_key) {
+      $flattened: map-merge($flattened, map_key_prefix_flatten($value, "#{$prefix}#{$key}:::", $flatten_exclude_key))
     } @else {
       $flattened: map-merge($flattened, (#{$prefix}#{$key}: $value));
     }

--- a/styles/framework/function/_map-key-prefix-flatten.scss
+++ b/styles/framework/function/_map-key-prefix-flatten.scss
@@ -1,7 +1,7 @@
 @function map_key_prefix_flatten($map, $prefix: "") {
   $flattened: empty_map();
   @each $key, $value in $map {
-    @if type-of($value) == "map" {
+    @if type-of($value) == "map" and not map-get($value, '_ref') {
       $flattened: map-merge($flattened, map_key_prefix_flatten($value, "#{$prefix}#{$key}:::"))
     } @else {
       $flattened: map-merge($flattened, (#{$prefix}#{$key}: $value));

--- a/styles/framework/settings/_init.scss
+++ b/styles/framework/settings/_init.scss
@@ -3,16 +3,23 @@ $FRAMEWORK_USED_SETTINGS: ();
 
 @mixin debug_settings_manifest() {
   @debug "Settings manifest =>";
-  @each $function in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
-    @debug $function;
+  @each $settings in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
+    @debug $settings;
   }
 }
 
 @mixin debug_settings() {
-  @debug "All available settings =>";
-  @each $function in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
-    @each $key, $value in map_key_prefix_flatten(call($function)) {
-      @debug "#{$key} : #{$value}";
+  @debug "All available settings (last-added is on top) =>";
+  $already_defined: ();
+  @each $settings in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
+    @debug "=== Clump Start ===";
+    @each $key, $value in map_key_prefix_flatten($settings) {
+      @if map-get($already_defined, $key) {
+        @debug "~~#{$key} : #{$value}~~ (overridden above)";
+      } @else {
+        @debug "#{$key} : #{$value}";
+      }
+      $already_defined: map-merge($already_defined, ($key: true));
     }
   }
 }
@@ -23,8 +30,8 @@ $FRAMEWORK_USED_SETTINGS: ();
 
 @function get_unused_settings() {
   $unused_entries: ();
-  @each $function in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
-    @each $key, $value in map_key_prefix_flatten(call($function)) {
+  @each $settings in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
+    @each $key, $value in map_key_prefix_flatten($settings) {
       @if index($FRAMEWORK_USED_SETTINGS, $key) == null {
         $unused_entries: append($unused_entries, ($key, $value), comma);
       }
@@ -33,28 +40,37 @@ $FRAMEWORK_USED_SETTINGS: ();
   @return $unused_entries;
 }
 
-@mixin add_settings_functions($functions...) {
-  $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL: join($functions, $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL) !global;
+@mixin add_settings($settings...) {
+  $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL: join($settings, $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL) !global;
 }
 
-@mixin remove_settings_functions($functions...) {
-  @each $function in $functions {
-    $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL: remove_value($FRAMEWORK_SETTINGS_MANIFEST_GLOBAL, $function) !global;
+@mixin remove_settings($settings...) {
+  @each $member in $settings {
+    $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL: remove_value($FRAMEWORK_SETTINGS_MANIFEST_GLOBAL, $member) !global;
   }
 }
 
-@mixin scoped_add_settings_functions($functions...) {
-  @include add_settings_functions($functions...);
+@mixin scoped_add_settings($settings...) {
+  @include add_settings($settings...);
   @content;
-  @include remove_settings_functions($functions...);
+  @include remove_settings($settings...);
 }
 
 @function settings($name, $default: enum('Object:::NONE')) {
-  @each $function in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
-    $function_settings: map_key_prefix_flatten(call($function));
+  @each $settings in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
+    $function_settings: map_key_prefix_flatten($settings);
     @if map-has-key($function_settings, $name) {
       $FRAMEWORK_USED_SETTINGS: append($FRAMEWORK_USED_SETTINGS, $name) !global;
-      @return map-deep-get($function_settings, $name);
+      $value: map-deep-get($function_settings, $name);
+      @if type-of($value) == map {
+        $ref: map-get($value, '_ref');
+        @if not $ref {
+          @return error(enum('Error:::INVALID_REFERENCE'), "Invalid reference in `#{$name}`.");
+        }
+        @return settings($ref, $default);
+      } @else {
+        @return $value
+      }
     }
   }
   @if $default != enum('Object:::NONE') {

--- a/styles/framework/settings/_init.scss
+++ b/styles/framework/settings/_init.scss
@@ -64,8 +64,8 @@ $FRAMEWORK_USED_SETTINGS: ();
       $value: map-deep-get($function_settings, $name);
       @if type-of($value) == map {
         $ref: map-get($value, '_ref');
-        @if not $ref {
-          @return error(enum('Error:::INVALID_REFERENCE'), "Invalid reference in `#{$name}`.");
+        @if not has_setting($ref) {
+          @return error(enum('Error:::INVALID_REFERENCE'), "Invalid reference `#{$ref}` in `#{$name}`.");
         }
         @return settings($ref, $default);
       } @else {
@@ -85,4 +85,14 @@ $FRAMEWORK_USED_SETTINGS: ();
     @return $settings-result;
   }
   @return error(enum('Error:::TYPE_ERROR'), "Received a disallowed NULL value for setting `#{$name}`.");
+}
+
+@function has_setting($name) {
+  @each $settings in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
+    $function_settings: map_key_prefix_flatten($settings);
+    @if map-has-key($function_settings, $name) {
+      @return true;
+    }
+  }
+  @return false;
 }

--- a/styles/framework/settings/_init.scss
+++ b/styles/framework/settings/_init.scss
@@ -1,6 +1,10 @@
 $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL: ();
 $FRAMEWORK_USED_SETTINGS: ();
 
+@function flatten_keep_references($settings) {
+  @return map_key_prefix_flatten($settings, '', '_ref');
+}
+
 @mixin debug_settings_manifest() {
   @debug "Settings manifest =>";
   @each $settings in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
@@ -13,7 +17,7 @@ $FRAMEWORK_USED_SETTINGS: ();
   $already_defined: ();
   @each $settings in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
     @debug "=== Clump Start ===";
-    @each $key, $value in map_key_prefix_flatten($settings) {
+    @each $key, $value in flatten_keep_references($settings) {
       @if map-get($already_defined, $key) {
         @debug "~~#{$key} : #{$value}~~ (overridden above)";
       } @else {
@@ -31,7 +35,7 @@ $FRAMEWORK_USED_SETTINGS: ();
 @function get_unused_settings() {
   $unused_entries: ();
   @each $settings in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
-    @each $key, $value in map_key_prefix_flatten($settings) {
+    @each $key, $value in flatten_keep_references($settings) {
       @if index($FRAMEWORK_USED_SETTINGS, $key) == null {
         $unused_entries: append($unused_entries, ($key, $value), comma);
       }
@@ -57,11 +61,11 @@ $FRAMEWORK_USED_SETTINGS: ();
 }
 
 @function settings($name, $default: enum('Object:::NONE')) {
-  @each $settings in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
-    $function_settings: map_key_prefix_flatten($settings);
-    @if map-has-key($function_settings, $name) {
+  @each $settings_member in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
+    $settings: flatten_keep_references($settings_member);
+    @if map-has-key($settings, $name) {
       $FRAMEWORK_USED_SETTINGS: append($FRAMEWORK_USED_SETTINGS, $name) !global;
-      $value: map-deep-get($function_settings, $name);
+      $value: map-deep-get($settings, $name);
       @if type-of($value) == map {
         $ref: map-get($value, '_ref');
         @if not has_setting($ref) {
@@ -80,17 +84,17 @@ $FRAMEWORK_USED_SETTINGS: ();
 }
 
 @function settings_not_null($name, $default: enum('Object:::NONE')) {
-  $settings-result: settings($name, $default);
-  @if $settings-result != null {
-    @return $settings-result;
+  $settings_result: settings($name, $default);
+  @if $settings_result != null {
+    @return $settings_result;
   }
   @return error(enum('Error:::TYPE_ERROR'), "Received a disallowed NULL value for setting `#{$name}`.");
 }
 
 @function has_setting($name) {
-  @each $settings in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
-    $function_settings: map_key_prefix_flatten($settings);
-    @if map-has-key($function_settings, $name) {
+  @each $settings_member in $FRAMEWORK_SETTINGS_MANIFEST_GLOBAL {
+    $settings: flatten_keep_references($settings_member);
+    @if map-has-key($settings, $name) {
       @return true;
     }
   }

--- a/styles/test/test-framework.scss
+++ b/styles/test/test-framework.scss
@@ -96,6 +96,15 @@ $test_settings_key_prefix_flatten: (
   )
 );
 
+$test_settings_with_reference: (
+  primaryColor: (_ref: design1Color),
+  design1Color: blue
+);
+
+$test_settings_with_invalid_reference: (
+  primaryColor: (_ref: invalidTarget),
+);
+
 
 @include describe('Settings') {
   @include it('can be added via map-returning functions') {
@@ -177,6 +186,23 @@ $test_settings_key_prefix_flatten: (
     @include assert-true(
       is_error(settings_not_null(non-existent-setting, null))
     );
+  }
+
+  @include it('settings supports looking up references') {
+    @include scoped_add_settings($test_settings_with_reference) {
+      @include assert-equal(
+        settings(primaryColor), 
+        blue
+      );
+    }
+  }
+
+  @include it('settings supports looking up references') {
+    @include scoped_add_settings($test_settings_with_invalid_reference) {
+      @include assert-true(
+        is_error(settings(primaryColor))
+      );
+    }
   }
 }
 
@@ -925,7 +951,9 @@ $test_note_grouped: (
   }
 
   @include it('outputs debug_settings') {
-    @include scoped_add_settings($test_note_grouped) {
+    @include scoped_add_settings(
+      $test_add_settings_function,
+      $test_add_settings_function_after) {
       @include debug_settings();
     }
   }

--- a/styles/test/test-framework.scss
+++ b/styles/test/test-framework.scss
@@ -250,6 +250,12 @@ $test_settings_with_invalid_reference: (
       'ENUM__Error:::TYPE_ERROR'
     );
   }
+  @include it('provides value INVALID_REFERENCE') {
+    @include assert-equal(
+      enum('Error:::INVALID_REFERENCE'),
+      'ENUM__Error:::INVALID_REFERENCE'
+    );
+  }
 }
 
 

--- a/styles/test/test-framework.scss
+++ b/styles/test/test-framework.scss
@@ -97,12 +97,16 @@ $test_settings_key_prefix_flatten: (
 );
 
 $test_settings_with_reference: (
-  primaryColor: (_ref: design1Color),
+  colorScheme: (
+    primaryColor: (_ref: design1Color),
+  ),
   design1Color: blue
 );
 
 $test_settings_with_invalid_reference: (
-  primaryColor: (_ref: invalidTarget),
+  colorScheme: (
+    primaryColor: (_ref: invalidTarget),
+  ),
 );
 
 
@@ -191,7 +195,7 @@ $test_settings_with_invalid_reference: (
   @include it('settings supports looking up references') {
     @include scoped_add_settings($test_settings_with_reference) {
       @include assert-equal(
-        settings(primaryColor), 
+        settings('colorScheme:::primaryColor'),
         blue
       );
     }
@@ -200,7 +204,7 @@ $test_settings_with_invalid_reference: (
   @include it('settings supports looking up references') {
     @include scoped_add_settings($test_settings_with_invalid_reference) {
       @include assert-true(
-        is_error(settings(primaryColor))
+        is_error(settings('colorScheme:::primaryColor'))
       );
     }
   }

--- a/styles/test/test-framework.scss
+++ b/styles/test/test-framework.scss
@@ -82,31 +82,24 @@ $DEBUG: true;
 }
 
 
-@function test_add_settings_function() {
-  @return (my-setting: test-value);
-}
+$test_add_settings_function: (my-setting: test-value);
 
-@function test_add_other_settings_function() {
-  @return (my-other-setting: other-test-value);
-}
+$test_add_other_settings_function: (my-other-setting: other-test-value);
 
-@function test_add_settings_function_after() {
-  @return (my-setting: overriden-value);
-}
+$test_add_settings_function_after: (my-setting: overriden-value);
 
-@function test_settings_key_prefix_flatten() {
-  @return (
-    rootkey: (
-      key: (
-        childkey: my-prefixed-value
-      )
+$test_settings_key_prefix_flatten: (
+  rootkey: (
+    key: (
+      childkey: my-prefixed-value
     )
-  );
-}
+  )
+);
+
 
 @include describe('Settings') {
   @include it('can be added via map-returning functions') {
-    @include scoped_add_settings_functions(get-function('test_add_settings_function')) {
+    @include scoped_add_settings($test_add_settings_function) {
       @include assert-equal(
         settings(my-setting),
         'test-value'
@@ -115,9 +108,7 @@ $DEBUG: true;
   }
 
   @include it('can add settings functions only to a certain scope if desired') {
-    @include scoped_add_settings_functions(
-      get-function('test_add_settings_function')
-    ) {}
+    @include scoped_add_settings($test_add_settings_function) {}
     @include assert-unequal(
       settings(my-setting),
       'test-value'
@@ -125,9 +116,7 @@ $DEBUG: true;
   }
 
   @include it('can access the settings with keys flattened') {
-    @include scoped_add_settings_functions(
-      get-function('test_settings_key_prefix_flatten')
-    ) {
+    @include scoped_add_settings($test_settings_key_prefix_flatten) {
       @include assert-equal(
         settings('rootkey:::key:::childkey'),
         'my-prefixed-value'
@@ -138,10 +127,7 @@ $DEBUG: true;
   @include it('can clear and output unused settings values') {
     $_: settings(my-setting);
     @include clear_used_settings();
-    @include scoped_add_settings_functions(
-      get-function('test_add_other_settings_function'),
-      get-function('test_add_settings_function')
-    ) {
+    @include scoped_add_settings($test_add_other_settings_function, $test_add_settings_function) {
       $_: settings(my-other-setting);
       @include assert-equal(
         get_unused_settings(),
@@ -151,18 +137,15 @@ $DEBUG: true;
   }
 
   @include it('prioritize settings functions added later (front of manifest)') {
-    @include scoped_add_settings_functions(get-function('test_add_settings_function')) {
-      @include scoped_add_settings_functions(get-function('test_add_settings_function_after')) {
+    @include scoped_add_settings($test_add_settings_function) {
+      @include scoped_add_settings($test_add_settings_function_after) {
         @include assert-equal(
           settings(my-setting),
           'overriden-value'
         );
       }
     }
-    @include scoped_add_settings_functions(
-      get-function('test_add_settings_function_after'),
-      get-function('test_add_settings_function')
-    ) {
+    @include scoped_add_settings($test_add_settings_function_after, $test_add_settings_function) {
       @include assert-equal(
         settings(my-setting),
         'overriden-value'
@@ -568,41 +551,33 @@ $test_subspace_with_groups_nonexist: (
   )
 );
 
-@function test_add_ChapterNote_context() {
-  @return ('ChapterNote:::_selectors': ('.chapter > ',));
-}
+$test_add_ChapterNote_context: ('ChapterNote:::_selectors': ('.chapter > ',));
 
-@function test_note_dual_context() {
-  @return (
-    ChapterNote: (
-      _selectors: ('.chapter > ', '.appendix > .special'),
-      container: (
-        background: yellow
-      )
+$test_note_dual_context: (
+  ChapterNote: (
+    _selectors: ('.chapter > ', '.appendix > .special'),
+    container: (
+      background: yellow
     )
-  );
-}
+  )
+);
 
-@function test_note_color_line_height() {
-  @return (
-    ChapterNote: (
-      _selectors: ('.chapter > ', '.appendix > .special'),
-      container: (
-        color: yellow,
-        line-height: 1.3rem
-      )
+$test_note_color_line_height: (
+  ChapterNote: (
+    _selectors: ('.chapter > ', '.appendix > .special'),
+    container: (
+      color: yellow,
+      line-height: 1.3rem
     )
-  );
-}
+  )
+);
 
-@function test_note_grouped() {
-  @return (
-    ChapterNote: (
-      _selectors: ('.chapter > ', '.appendix > .special'),
-      note-border-color: lightgrey
-    )
-  );
-}
+$test_note_grouped: (
+  ChapterNote: (
+    _selectors: ('.chapter > ', '.appendix > .special'),
+    note-border-color: lightgrey
+  )
+);
 
 @include describe("Design Space") {
   @include it('errors when get_space errors when name does not exist') {
@@ -642,7 +617,7 @@ $test_subspace_with_groups_nonexist: (
   }
 
   @include it('errors when a superspace has a bad schema') {
-    @include scoped_add_settings_functions(get-function('test_add_ChapterNote_context')) {
+    @include scoped_add_settings($test_add_ChapterNote_context) {
       @include assert {
         @include output {
           @include scoped_create_superspace('TestNote', $test_note_space_bad_schema_first) {}
@@ -732,7 +707,7 @@ $test_subspace_with_groups_nonexist: (
   }
 
   @include it('errors when required setting is missing') {
-    @include scoped_add_settings_functions(get-function('test_add_ChapterNote_context')) {
+    @include scoped_add_settings($test_add_ChapterNote_context) {
       @include scoped_create_superspace('TestNote', $test_note_space) {
         @include assert {
           @include output {
@@ -749,7 +724,7 @@ $test_subspace_with_groups_nonexist: (
     }
 
     @include it('errors when required setting is missing - subspace') {
-      @include scoped_add_settings_functions(get-function('test_add_ChapterNote_context')) {
+      @include scoped_add_settings($test_add_ChapterNote_context) {
         @include scoped_create_superspace('TestNote', $test_note_space) {
           @include scoped_create_subspace('SpecificTestNote', 'TestNote', $test_subspace) {
             @include assert {
@@ -770,7 +745,7 @@ $test_subspace_with_groups_nonexist: (
   }
 
   @include it('allows use of the same subspace with different settings') {
-    @include scoped_add_settings_functions(get-function('test_note_dual_context')) {
+    @include scoped_add_settings($test_note_dual_context) {
       @include scoped_create_superspace('TestNote', $test_note_space) {
         @include scoped_create_subspace('SpecificTestNote', 'TestNote', $test_subspace) {
           @include assert {
@@ -790,7 +765,7 @@ $test_subspace_with_groups_nonexist: (
   }
 
   @include it('allows ValueSets to include a default value if setting is missing') {
-    @include scoped_add_settings_functions(get-function('test_add_ChapterNote_context')) {
+    @include scoped_add_settings($test_add_ChapterNote_context) {
       @include scoped_create_superspace('TestNote', $test_note_space) {
         @include scoped_create_subspace('SpecificTestNote', 'TestNote', $test_subspace_with_default) {
           @include assert {
@@ -810,7 +785,7 @@ $test_subspace_with_groups_nonexist: (
   }
 
   @include it('allows setting groups for a space') {
-    @include scoped_add_settings_functions(get-function('test_note_grouped')) {
+    @include scoped_add_settings($test_note_grouped) {
       @include scoped_create_superspace('TestNote', $test_note_space) {
         @include scoped_create_subspace('SpecificTestNote', 'TestNote', $test_subspace_with_groups) {
           @include assert {
@@ -830,7 +805,7 @@ $test_subspace_with_groups_nonexist: (
   }
 
   @include it('allows group to point to another group') {
-    @include scoped_add_settings_functions(get-function('test_note_grouped')) {
+    @include scoped_add_settings($test_note_grouped) {
       @include scoped_create_superspace('TestNote', $test_note_space) {
         @include scoped_create_subspace('SpecificTestNote', 'TestNote', $test_subspace_with_groups_twostep) {
           @include assert {
@@ -850,7 +825,7 @@ $test_subspace_with_groups_nonexist: (
   }
 
   @include it('errors when a referenced group does not exist') {
-    @include scoped_add_settings_functions(get-function('test_note_grouped')) {
+    @include scoped_add_settings($test_note_grouped) {
       @include scoped_create_superspace('TestNote', $test_note_space) {
         @include scoped_create_subspace('SpecificTestNote', 'TestNote', $test_subspace_with_groups_nonexist) {
           @include assert {
@@ -870,7 +845,7 @@ $test_subspace_with_groups_nonexist: (
   }
 
   @include it('forbids subspaces from being more general') {
-    @include scoped_add_settings_functions(get-function('test_add_ChapterNote_context')) {
+    @include scoped_add_settings($test_add_ChapterNote_context) {
       @include scoped_create_superspace('TestNote', $test_note_space) {
         @include scoped_create_subspace('SpecificTestNote', 'TestNote', $test_not_real_subspace_first) {
           @include assert {
@@ -898,7 +873,7 @@ $test_subspace_with_groups_nonexist: (
             }
           }
         }
-        @include scoped_add_settings_functions(get-function('test_note_color_line_height')) {
+        @include scoped_add_settings($test_note_color_line_height) {
           @include scoped_create_subspace('SpecificTestNote', 'TestNote', $test_not_real_subspace_third) {
             @include assert {
               @include output {
@@ -919,7 +894,7 @@ $test_subspace_with_groups_nonexist: (
   
 
   @include it('can debug output of all parents of a subspace') {
-    @include scoped_add_settings_functions(get-function('test_note_grouped')) {
+    @include scoped_add_settings($test_note_grouped) {
       @include scoped_create_superspace('TestNote', $test_note_space) {
         @include scoped_create_subspace('SpecificTestNote', 'TestNote', $test_subspace_with_groups) {
           @include assert-equal(
@@ -944,13 +919,13 @@ $test_subspace_with_groups_nonexist: (
   }
 
   @include it('outputs debug_settings_manifest') {
-    @include scoped_add_settings_functions(get-function('test_note_grouped')) {
+    @include scoped_add_settings($test_note_grouped) {
       @include debug_settings_manifest();
     }
   }
 
   @include it('outputs debug_settings') {
-    @include scoped_add_settings_functions(get-function('test_note_grouped')) {
+    @include scoped_add_settings($test_note_grouped) {
       @include debug_settings();
     }
   }


### PR DESCRIPTION
This allows a setting to reference another setting using a `(_ref: targetSetting)` rather than rely on being inside a function closure. It also updates the `debug_settings()` to show when a setting has been overridden.

# Example

```sass
@include add_settings((

  primaryColor: blue,

  ChapterNote: (
    _selectors: ('.chapter > '),
    'container': (
      color: (_ref: primaryColor),
    )
  )
));
```