### PR TITLE
Fix release chart

### DIFF
--- a/RELEASE_FLAGS.md
+++ b/RELEASE_FLAGS.md
@@ -1,3 +1,5 @@
+| Recipe Name | chapter-page-class | toc-numbered-pages | appendix-has-numbered-examples | increment-section-counter-for-lo | trash-abstract-in-preface | EOCsection-links | appendix-top-title-copy |
+| --- | --- | --- | --- | --- | --- | --- | --- |
 | microbiology | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: |
 | anatomy | :x: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :x: | :x: |
 | history | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: |

--- a/js/check-release-flag-enabled/extract-chart.js
+++ b/js/check-release-flag-enabled/extract-chart.js
@@ -9,7 +9,7 @@ getStdin().then(recipeFeaturesScss => {
     const recipeName = rendered.vars['global']['$RECIPE_NAME']['value']
     const features = rendered.vars['global']['$RELEASE_FLAGS']['value']
 
-    if (order === 0) {
+    if (order === '0') {
       let headerRow = '| Recipe Name |'
       let headerBorder = '| --- |'
       Object.keys(features).forEach(featureName => {

--- a/js/check-release-flag-enabled/extract-chart.js
+++ b/js/check-release-flag-enabled/extract-chart.js
@@ -1,6 +1,6 @@
 const getStdin = require('get-stdin')
 const sassExtract = require('sass-extract')
-const order = process.argv[2]
+const order = Number.parseInt(process.argv[2])
 
 getStdin().then(recipeFeaturesScss => {
   sassExtract.render({
@@ -9,7 +9,7 @@ getStdin().then(recipeFeaturesScss => {
     const recipeName = rendered.vars['global']['$RECIPE_NAME']['value']
     const features = rendered.vars['global']['$RELEASE_FLAGS']['value']
 
-    if (order === '0') {
+    if (order === 0) {
       let headerRow = '| Recipe Name |'
       let headerBorder = '| --- |'
       Object.keys(features).forEach(featureName => {


### PR DESCRIPTION
The update to the latest node version broke the release flag chart because `order` now is `'0'` rather than `0` and no longer passes the the if statement