### PR TITLE
Add script/run to run commands in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@
 
 # Create a baked pdf for a new book
 
-1. Run `docker-compose run --rm -e HOST=katalyst01.cnx.org fetch-html --with-resources intro-business` to download the cnxml from the server to create the single-file HTML for the book.
+1. Run `docker-compose run --rm -e HOST=katalyst01.cnx.org fetch-book --with-resources intro-business` to download the cnxml from the server.
    - **Note:** To see the list of books available see `./books.txt`
+1. Run `docker-compose run --rm assemble-book intro-business` to create the single-file HTML for the book.
 1. Run `docker-compose run --rm bake-book intro-business` to convert the single-file HTML locally into the "baked" book.
 1. Run `docker-compose run --rm mathify-book intro-business` to convert all the math to svg.
 1. Run `docker-compose run --rm build-pdf intro-business` to create the pdf.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,3 +88,15 @@ services:
     image: openstax/princexml
     volumes:
       - "${HOST_PWD:-.}/data:/out"
+
+  command:
+    build: .
+    image: openstax/cnx-recipes
+    environment:
+      # This is necessary in order to mount the correct directory if we start
+      # sibling containers
+      HOST_PWD: "${PWD}"
+      OUTPUT_DIR: /out
+    volumes:
+      - .:/code
+      - /var/run/docker.sock:/var/run/docker.sock

--- a/script/bake-book
+++ b/script/bake-book
@@ -83,8 +83,9 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   fi
 
   if [ -f "${style_file}" ]; then
+    ln "${style_file}" "./data/${book_name}"
     do_progress_quiet "Adding style file ${style_file}" \
-      sed -i "s%<\/head>%<link rel=\"stylesheet\" type=\"text/css\" href=\"../../${style_file}\" />&%" "${baked_file}"
+      sed -i "s%<\/head>%<link rel=\"stylesheet\" type=\"text/css\" href=\"$(basename "${style_file}")\" />&%" "${baked_file}"
   fi
 
   if [ -f /.dockerenv ]; then

--- a/script/bake-book
+++ b/script/bake-book
@@ -86,6 +86,8 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
     ln "${style_file}" "./data/${book_name}"
     do_progress_quiet "Adding style file ${style_file}" \
       sed -i "s%<\/head>%<link rel=\"stylesheet\" type=\"text/css\" href=\"$(basename "${style_file}")\" />&%" "${baked_file}"
+  elif [ -n "${STYLE}" ] || [ -n "${style_name}" ]; then
+    _say "${c_red}WARNING${c_none} style not found: ${style_file}"
   fi
 
   if [ -f /.dockerenv ]; then

--- a/script/build-pdf
+++ b/script/build-pdf
@@ -54,7 +54,7 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
 
   style_flag=()
   if [ -f "${style_file}" ]; then
-    style_flag=('--style' "./${book_name}/$(basename "${style_file}")")
+    style_flag=('--style' "${book_dir}/$(basename "${style_file}")")
     cp "${style_file}" "./data/${book_name}"
   fi
 

--- a/script/build-pdf
+++ b/script/build-pdf
@@ -56,6 +56,8 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   if [ -f "${style_file}" ]; then
     style_flag=('--style' "${book_dir}/$(basename "${style_file}")")
     cp "${style_file}" "./data/${book_name}"
+  elif [ -n "${STYLE}" ] || [ -n "${style_name}" ]; then
+    _say "${c_red}WARNING${c_none} style not found: ${style_file}"
   fi
 
   # Run princexml as root to bypass permission issues:

--- a/script/run
+++ b/script/run
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+env_vars=()
+
+while echo "$1" | grep -q '='
+do
+  env_vars[${#env_vars[@]}]='-e'
+  env_vars[${#env_vars[@]}]="$1"
+  shift
+done
+
+if [ ! -d node_modules ]
+then
+  docker-compose run --rm command "./script/setup"
+fi
+docker-compose run --rm "${env_vars[@]}" command "$@"
+docker-compose run --rm command /bin/bash -c "find ! -path './node_modules/*' ! -path './venv/*' ! -path './vendor/*' -user root -exec chown \"\$(stat -c '%u:%g' ./)\" '{}' \;"


### PR DESCRIPTION
- Add script/run to run commands in docker

  - Add a "command" service in docker-compose.yml
  
    In addition to specific baked pdf commands, we need a generic service to
    run all the scripts in cnx-recipes using docker-compose.  Since we're
    trying to solve the cnx-recipes installation issue, we need to contain
    everything inside docker.
  
  - Add a wrapper script to run commands using docker-compose:
  
    ```
    docker-compose run --rm command ...
    ```
  
    To run something like:
  
    ```
    PLATFORM=pdf node ./styles/build/build.js ./styles/books/anatomy/book.scss
    ```
  
    just prepend with `./script/run`:
  
    ```
    ./script/run PLATFORM=pdf node ./styles/build/build.js ./styles/books/anatomy/book.scss
    ```

- Fix path to style file when running prince

  It was not looking up the correct path to the style file so prince
  couldn't apply the style when generating the pdf.

- Move bake-book style css to the book output directory

  The `bake-book` command includes a link to
  `./styles/output/<style-name>.css` but when it got to the `build-pdf`
  command, it doesn't have access to the styles directory, we need to the
  file to be in the book output directory for it to work.

---

@wilkus27 This should fix the problem you were having:

So if you prepend all the commands you were running with `./script/run` (except any commands starting with `docker-compose`), the commands should run inside docker and wouldn't have the problem with venv.