### PR TITLE
Allow px on root element settings in generic

### DIFF
--- a/styles/templates/generic/_typography.scss
+++ b/styles/templates/generic/_typography.scss
@@ -2,6 +2,7 @@
 
 //usage in settings file: font-family: (_ref: 'typography:::sansFont'),
 
+/* stylelint-disable-next-line meowtec/no-px */
 @include add_settings((
   typography: (
     sansFont: "IBM Plex Sans",


### PR DESCRIPTION
stylelint supports comments for disabling the linter for a particular line or block. See [their documentation](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#turning-rules-off-from-within-your-css) for more details. In general we do not want to write exceptions, but for the root element, this is fine, since we plan on using rem/em for everything else.