### PR TITLE
Change order of spans in captions

### DIFF
--- a/recipes/books/_common-stuff.scss
+++ b/recipes/books/_common-stuff.scss
@@ -21,6 +21,13 @@ $Config_PartType_Figure_CaptionContent  : (os-title-label: "Figure ", os-number:
 $Config_PartType_Figure_CaptionContentAp: (os-title-label: "Figure ", os-number: counter(appendix, upper-alpha) counter(figure), os-divider: " "); //TODO: Make a counter for both chapter and appendix, and automate the switch between standard and upper alpha counting?
 $Config_PartType_Figure_CaptionContentPr: (os-title-label: "Figure ", os-number: counter(figure), os-divider: " ");
 
+// Here we can determine order of spans creating captions of figures and tabels.
+// bCaption - contains all spans defined in $Config_PartType_Table(Figure)_CaptionContent(Ap)(Pr),
+// bCaptionTitle - contains span with default title of figure or table
+// bCaptionDivider - contains span with blank space
+// bCaptionContent - contains span with default content of caption
+$Config_FigTable_CaptionContentOrder: (bCaption, bCaptionTitle, bCaptionDivider, bCaptionContent);
+
 $Config_ContentExercise_TitleContent : (os-number : counter(exerciseMaybeInContent), os-title-label : "Exercise ");
 $Config_ContentSolution_TitleContent : null; // It seems that this is null for all books
 $Config_ContentExercise_TitleContentAp : (os-number : counter(exerciseMaybeInContent), os-title-label : "Exercise ");

--- a/recipes/books/_common-stuff.scss
+++ b/recipes/books/_common-stuff.scss
@@ -14,6 +14,8 @@ $Config_PartType_Chapter_TitleContent   : (os-number: counter(chapter), os-divid
 $Config_PartType_Appendix_TitleContent  : (os-number: counter(appendix, upper-alpha), os-divider: ' | ');
 $Config_PartType_Section_TitleContent   : (os-number: counter(chapter) "." counter(section), os-divider: ' ' );
 
+$Config_Section_TitleContentOrder: (bSectionLabel, content());
+
 $Config_PartType_Table_CaptionContent   : (os-title-label: "Table ", os-number: counter(chapter) "." counter(table), os-divider: " "); //TODO: Make a counter for both chapter and appendix, and automate the switch between standard and upper alpha counting?
 $Config_PartType_Table_CaptionContentAp : (os-title-label: "Table ", os-number: counter(appendix, upper-alpha)  counter(table), os-divider: " ");
 $Config_PartType_Table_CaptionContentPr : (os-title-label: "Table ", os-number: counter(table), os-divider: " ");

--- a/recipes/books/_generator.scss
+++ b/recipes/books/_generator.scss
@@ -509,8 +509,8 @@
     @include count_countFigures(figure);
   }
 
-  @include number_setCaptions($Config_SetTableCaption, $Config_PartType_Table_CaptionContent, $Config_PartType_Table_CaptionContentAp, $Config_PartType_Table_CaptionContentPr);
-  @include number_setCaptions($Config_SetFigureCaption, $Config_PartType_Figure_CaptionContent, $Config_PartType_Figure_CaptionContentAp, $Config_PartType_Figure_CaptionContentPr);
+  @include number_setCaptions($Config_SetTableCaption, $Config_PartType_Table_CaptionContent, $Config_FigTable_CaptionContentOrder, $Config_PartType_Table_CaptionContentAp, $Config_PartType_Table_CaptionContentPr);
+  @include number_setCaptions($Config_SetFigureCaption, $Config_PartType_Figure_CaptionContent, $Config_FigTable_CaptionContentOrder, $Config_PartType_Figure_CaptionContentAp, $Config_PartType_Figure_CaptionContentPr);
 
   @if release-flag-enabled(trash-abstract-in-preface) {
     @include modify_trash('.preface [data-type="abstract"]');

--- a/recipes/books/_generator.scss
+++ b/recipes/books/_generator.scss
@@ -164,7 +164,7 @@
   @include count_countAppendices(appendix);
   @include number_numberAppendices($Config_PartType_Appendix_TitleContent);
   @include count_countSections(section);
-  @include number_numberSections($Config_PartType_Section_TitleContent);
+  @include number_numberSections($Config_PartType_Section_TitleContent, $Config_Section_TitleContentOrder);
   @include count_footnotes(footnotes);
   @include count_footnoteLinks(footnoteLinks);
   @include number_footnotes(footnotes, footnoteLinks);

--- a/recipes/mixins/_all.scss
+++ b/recipes/mixins/_all.scss
@@ -4,6 +4,7 @@
 @import './_link';
 @import './_modify';
 @import './_number';
+@import './_order';
 @import './_reference';
 @import './_toc';
 @import './_utils';

--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -153,7 +153,7 @@
   }
 }
 
-@mixin number_setCaptions($setFigTableCaptions, $labeling, $labelingAp, $labelingPr: null) {
+@mixin number_setCaptions($setFigTableCaptions, $labeling, $figTableConfig, $labelingAp, $labelingPr: null) {
   $captionType:         map-get($setFigTableCaptions, captionType);
   $defaultContainer:    map-get($setFigTableCaptions, defaultContainer);
   $hasCaption:          map-get($setFigTableCaptions, hasCaption);
@@ -206,7 +206,7 @@
           }
         }
       }
-      @include setCaptionsHelper($captionType, $defaultContainer, $hasCaption, $hasTitle, $hasTopTitle);
+      @include setCaptionsHelper($captionType, $defaultContainer, $hasCaption, $hasTitle, $hasTopTitle, $figTableConfig);
     }
     @include trashUnnumberedCaption($elementName, $defaultContainer);
   }
@@ -214,7 +214,7 @@
     :not(#{$elementName}) > #{$elementName}:not(.unnumbered),
     > #{$elementName}:not(.unnumbered) {
       @include utils_title($labelingAp, bCaption);
-      @include setCaptionsHelper($captionType, $defaultContainer, $hasCaption, $hasTitle, $hasTopTitle);
+      @include setCaptionsHelper($captionType, $defaultContainer, $hasCaption, $hasTitle, $hasTopTitle, $figTableConfig);
       @if ($hasTopTitle and release-flag-enabled(appendix-top-title-copy)) {
         &.top-titled {
           //this will have to be rewritten after all the content has been updated to contain the title within the title instead of the hacky first header in the table.
@@ -231,7 +231,7 @@
     .preface {
       :not(#{$elementName}) > #{$elementName}:not(.unnumbered) {
         @include utils_title($labelingPr, bCaption);
-        @include setCaptionsHelper($captionType, $defaultContainer, $hasCaption, $hasTitle, $hasTopTitle);
+        @include setCaptionsHelper($captionType, $defaultContainer, $hasCaption, $hasTitle, $hasTopTitle, $figTableConfig);
       }
       @include trashUnnumberedCaption($elementName, $defaultContainer);
     }
@@ -314,7 +314,7 @@
   }
 }
 
-@mixin setCaptionsHelper($captionType, $defaultContainer, $hasCaption, $hasTitle, $hasTopTitle) {
+@mixin setCaptionsHelper($captionType, $defaultContainer, $hasCaption, $hasTitle, $hasTopTitle, $figTableConfig) {
 
   @if ($hasCaption) {
     #{$defaultContainer} {
@@ -348,10 +348,16 @@
       @error "BUG: Invalid captionType '#{$captionType}'";
     }
   }
+
+  $partOne: nth($figTableConfig, 1);
+  $partTwo: nth($figTableConfig, 2);
+  $partThree: nth($figTableConfig, 3);
+  $partFour: nth($figTableConfig, 4);
+
   &::after {
     container: div;
     class: "os-caption-container";
-    content: pending(bCaption) pending(bCaptionTitle) pending(bCaptionDivider) pending(bCaptionContent);
+    content: pending($partOne) pending($partTwo) pending($partThree) pending($partFour);
     move-to: bCaptionContainer;
   }
   @if $captionType == $CAPTION_TABLE {

--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -22,14 +22,14 @@
   }
 }
 
-@mixin number_numberSections($sectionTitleContent) {
+@mixin number_numberSections($sectionTitleContent, $sectionTitleContentOrder) {
   div[data-type="chapter"] > div[data-type="page"] {
     &:not(.introduction) {
       @include utils_title($sectionTitleContent, bSectionLabel);
       //use the title mixin for this? and that way content() can be wrapped
       > [data-type="document-title"] {
         container: h2;
-        content: pending(bSectionLabel) content();
+        content: contentOrder($sectionTitleContentOrder);
       }
     }
     &.introduction {
@@ -351,7 +351,7 @@
   &::after {
     container: div;
     class: "os-caption-container";
-    content: contentOrder($figTableConfig, 4);
+    content: contentOrder($figTableConfig);
     move-to: bCaptionContainer;
   }
   @if $captionType == $CAPTION_TABLE {

--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -348,16 +348,10 @@
       @error "BUG: Invalid captionType '#{$captionType}'";
     }
   }
-
-  $partOne: nth($figTableConfig, 1);
-  $partTwo: nth($figTableConfig, 2);
-  $partThree: nth($figTableConfig, 3);
-  $partFour: nth($figTableConfig, 4);
-
   &::after {
     container: div;
     class: "os-caption-container";
-    content: pending($partOne) pending($partTwo) pending($partThree) pending($partFour);
+    content: contentOrder($figTableConfig, 4);
     move-to: bCaptionContainer;
   }
   @if $captionType == $CAPTION_TABLE {

--- a/recipes/mixins/_order.scss
+++ b/recipes/mixins/_order.scss
@@ -1,10 +1,12 @@
-@function contentOrder($orderConfig, $bucketsNumber) {
+@function contentOrder($orderConfig) {
     $value: null;
 
-    @for $i from 1 to $bucketsNumber +1 {
-        $bucket: nth($orderConfig, $i);
-        $value: $value pending($bucket);
+    @each $element in $orderConfig {
+        @if $element == 'content()' {
+            $value: $value $element;
+        } @else {
+            $value: $value pending($element);
+        }
     }
-
     @return $value;
 }

--- a/recipes/mixins/_order.scss
+++ b/recipes/mixins/_order.scss
@@ -1,0 +1,10 @@
+@function contentOrder($orderConfig, $bucketsNumber) {
+    $value: null;
+
+    @for $i from 1 to $bucketsNumber +1 {
+        $bucket: nth($orderConfig, $i);
+        $value: $value pending($bucket);
+    }
+
+    @return $value;
+}


### PR DESCRIPTION
We want to be able to decide in `config.scss` or `common-stuff.scss` file about order of all spans creating captions of figures and tables: 

![image](https://user-images.githubusercontent.com/40228854/60596509-7a653e00-9da9-11e9-9bc8-26c52b4d6ff1.png)

At this moment we can change order only for `os-title-label`,`os-number` and `os-divider`.