### PR TITLE
Exercise label order

### DIFF
--- a/RELEASE_FLAGS.md
+++ b/RELEASE_FLAGS.md
@@ -1,25 +1,25 @@
-| Recipe Name | chapter-page-class | toc-numbered-pages | appendix-has-numbered-examples | increment-section-counter-for-lo | trash-abstract-in-preface | EOCsection-links | titles-in-examples | module-titled-notes | appendix-top-title-copy | custom-lists |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| precalculus | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: |
-| microbiology | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| anatomy | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: |
-| history | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: |
-| psychology | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| chemistry | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: |
-| astronomy | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| principles-management | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: |
-| entrepreneurship | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: |
-| accounting | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: |
-| business-ethics | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: |
-| intro-business | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: |
-| statistics | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| economics | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| biology | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| ap-biology | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| physics | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| ap-physics | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| u-physics | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| sociology | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| dev-math | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: |
-| american-government | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
-| calculus | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: |
+| Recipe Name | chapter-page-class | toc-numbered-pages | appendix-has-numbered-examples | increment-section-counter-for-lo | trash-abstract-in-preface | EOCsection-links | titles-in-examples | module-titled-notes | appendix-top-title-copy | custom-lists | exercise-label-order |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| precalculus | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: |
+| microbiology | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| anatomy | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: |
+| history | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: |
+| psychology | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| chemistry | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: | :x: |
+| astronomy | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| principles-management | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: |
+| entrepreneurship | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: |
+| accounting | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: |
+| business-ethics | :x: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: |
+| intro-business | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: |
+| statistics | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| economics | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| biology | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
+| ap-biology | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| physics | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |
+| ap-physics | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| u-physics | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| sociology | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| dev-math | :x: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: | :x: |
+| american-government | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: | :x: |
+| calculus | :x: | :x: | :x: | :x: | :x: | :x: | :heavy_check_mark: | :x: | :x: | :heavy_check_mark: | :heavy_check_mark: |

--- a/foo.diff
+++ b/foo.diff
@@ -1,0 +1,2128 @@
+1191370,1191372d1191369
+<             ><span
+<                 class="os-divider"
+<               > </span
+1191376a1191374,1191376
+>             ><span
+>                 class="os-divider"
+>               > </span
+1191553,1191555d1191552
+<             ><span
+<                 class="os-divider"
+<               > </span
+1191559a1191557,1191559
+>             ><span
+>                 class="os-divider"
+>               > </span
+1191668,1191670d1191667
+<             ><span
+<                 class="os-divider"
+<               > </span
+1191674a1191672,1191674
+>             ><span
+>                 class="os-divider"
+>               > </span
+1191729,1191731d1191728
+<             ><span
+<                 class="os-divider"
+<               > </span
+1191735a1191733,1191735
+>             ><span
+>                 class="os-divider"
+>               > </span
+1191926,1191928d1191925
+<             ><span
+<                 class="os-divider"
+<               > </span
+1191932a1191930,1191932
+>             ><span
+>                 class="os-divider"
+>               > </span
+1192031,1192033d1192030
+<             ><span
+<                 class="os-divider"
+<               > </span
+1192037a1192035,1192037
+>             ><span
+>                 class="os-divider"
+>               > </span
+1192116,1192118d1192115
+<             ><span
+<                 class="os-divider"
+<               > </span
+1192122a1192120,1192122
+>             ><span
+>                 class="os-divider"
+>               > </span
+1192169,1192171d1192168
+<             ><span
+<                 class="os-divider"
+<               > </span
+1192175a1192173,1192175
+>             ><span
+>                 class="os-divider"
+>               > </span
+1192280,1192282d1192279
+<             ><span
+<                 class="os-divider"
+<               > </span
+1192286a1192284,1192286
+>             ><span
+>                 class="os-divider"
+>               > </span
+1192481,1192483d1192480
+<             ><span
+<                 class="os-divider"
+<               > </span
+1192487a1192485,1192487
+>             ><span
+>                 class="os-divider"
+>               > </span
+1192550,1192552d1192549
+<             ><span
+<                 class="os-divider"
+<               > </span
+1192556a1192554,1192556
+>             ><span
+>                 class="os-divider"
+>               > </span
+1192675,1192677d1192674
+<             ><span
+<                 class="os-divider"
+<               > </span
+1192681a1192679,1192681
+>             ><span
+>                 class="os-divider"
+>               > </span
+1192794,1192796d1192793
+<             ><span
+<                 class="os-divider"
+<               > </span
+1192800a1192798,1192800
+>             ><span
+>                 class="os-divider"
+>               > </span
+1192813,1192815d1192812
+<             ><span
+<                 class="os-divider"
+<               > </span
+1192819a1192817,1192819
+>             ><span
+>                 class="os-divider"
+>               > </span
+1192848,1192850d1192847
+<             ><span
+<                 class="os-divider"
+<               > </span
+1192854a1192852,1192854
+>             ><span
+>                 class="os-divider"
+>               > </span
+1193041,1193043d1193040
+<             ><span
+<                 class="os-divider"
+<               > </span
+1193047a1193045,1193047
+>             ><span
+>                 class="os-divider"
+>               > </span
+1193108,1193110d1193107
+<             ><span
+<                 class="os-divider"
+<               > </span
+1193114a1193112,1193114
+>             ><span
+>                 class="os-divider"
+>               > </span
+1193161,1193163d1193160
+<             ><span
+<                 class="os-divider"
+<               > </span
+1193167a1193165,1193167
+>             ><span
+>                 class="os-divider"
+>               > </span
+1193306,1193308d1193305
+<             ><span
+<                 class="os-divider"
+<               > </span
+1193312a1193310,1193312
+>             ><span
+>                 class="os-divider"
+>               > </span
+1193343,1193345d1193342
+<             ><span
+<                 class="os-divider"
+<               > </span
+1193349a1193347,1193349
+>             ><span
+>                 class="os-divider"
+>               > </span
+1193546,1193548d1193545
+<             ><span
+<                 class="os-divider"
+<               > </span
+1193552a1193550,1193552
+>             ><span
+>                 class="os-divider"
+>               > </span
+1193733,1193735d1193732
+<             ><span
+<                 class="os-divider"
+<               > </span
+1193739a1193737,1193739
+>             ><span
+>                 class="os-divider"
+>               > </span
+1193752,1193754d1193751
+<             ><span
+<                 class="os-divider"
+<               > </span
+1193758a1193756,1193758
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194009,1194011d1194008
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194015a1194013,1194015
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194044,1194046d1194043
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194050a1194048,1194050
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194285,1194287d1194284
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194291a1194289,1194291
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194394,1194396d1194393
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194400a1194398,1194400
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194467,1194469d1194466
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194473a1194471,1194473
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194604,1194606d1194603
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194610a1194608,1194610
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194669,1194671d1194668
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194675a1194673,1194675
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194722,1194724d1194721
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194728a1194726,1194728
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194759,1194761d1194758
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194765a1194763,1194765
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194832,1194834d1194831
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194838a1194836,1194838
+>             ><span
+>                 class="os-divider"
+>               > </span
+1194917,1194919d1194916
+<             ><span
+<                 class="os-divider"
+<               > </span
+1194923a1194921,1194923
+>             ><span
+>                 class="os-divider"
+>               > </span
+1209181,1209183d1209180
+<             ><span
+<                 class="os-divider"
+<               > </span
+1209187a1209185,1209187
+>             ><span
+>                 class="os-divider"
+>               > </span
+1209200,1209202d1209199
+<             ><span
+<                 class="os-divider"
+<               > </span
+1209206a1209204,1209206
+>             ><span
+>                 class="os-divider"
+>               > </span
+1209219,1209221d1209218
+<             ><span
+<                 class="os-divider"
+<               > </span
+1209225a1209223,1209225
+>             ><span
+>                 class="os-divider"
+>               > </span
+1209240,1209242d1209239
+<             ><span
+<                 class="os-divider"
+<               > </span
+1209246a1209244,1209246
+>             ><span
+>                 class="os-divider"
+>               > </span
+1209355,1209357d1209354
+<             ><span
+<                 class="os-divider"
+<               > </span
+1209361a1209359,1209361
+>             ><span
+>                 class="os-divider"
+>               > </span
+1209450,1209452d1209449
+<             ><span
+<                 class="os-divider"
+<               > </span
+1209456a1209454,1209456
+>             ><span
+>                 class="os-divider"
+>               > </span
+1209573,1209575d1209572
+<             ><span
+<                 class="os-divider"
+<               > </span
+1209579a1209577,1209579
+>             ><span
+>                 class="os-divider"
+>               > </span
+1209836,1209838d1209835
+<             ><span
+<                 class="os-divider"
+<               > </span
+1209842a1209840,1209842
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210119,1210121d1210118
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210125a1210123,1210125
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210598,1210600d1210597
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210604a1210602,1210604
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210617,1210619d1210616
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210623a1210621,1210623
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210666,1210668d1210665
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210672a1210670,1210672
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210685,1210687d1210684
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210691a1210689,1210691
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210730,1210732d1210729
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210736a1210734,1210736
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210775,1210777d1210774
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210781a1210779,1210781
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210794,1210796d1210793
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210800a1210798,1210800
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210839,1210841d1210838
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210845a1210843,1210845
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210963,1210965d1210962
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210969a1210967,1210969
+>             ><span
+>                 class="os-divider"
+>               > </span
+1210982,1210984d1210981
+<             ><span
+<                 class="os-divider"
+<               > </span
+1210988a1210986,1210988
+>             ><span
+>                 class="os-divider"
+>               > </span
+1211001,1211003d1211000
+<             ><span
+<                 class="os-divider"
+<               > </span
+1211007a1211005,1211007
+>             ><span
+>                 class="os-divider"
+>               > </span
+1211020,1211022d1211019
+<             ><span
+<                 class="os-divider"
+<               > </span
+1211026a1211024,1211026
+>             ><span
+>                 class="os-divider"
+>               > </span
+1211150,1211152d1211149
+<             ><span
+<                 class="os-divider"
+<               > </span
+1211156a1211154,1211156
+>             ><span
+>                 class="os-divider"
+>               > </span
+1211203,1211205d1211202
+<             ><span
+<                 class="os-divider"
+<               > </span
+1211209a1211207,1211209
+>             ><span
+>                 class="os-divider"
+>               > </span
+1211222,1211224d1211221
+<             ><span
+<                 class="os-divider"
+<               > </span
+1211228a1211226,1211228
+>             ><span
+>                 class="os-divider"
+>               > </span
+1211287,1211289d1211286
+<             ><span
+<                 class="os-divider"
+<               > </span
+1211293a1211291,1211293
+>             ><span
+>                 class="os-divider"
+>               > </span
+1211306,1211308d1211305
+<             ><span
+<                 class="os-divider"
+<               > </span
+1211312a1211310,1211312
+>             ><span
+>                 class="os-divider"
+>               > </span
+1211485,1211487d1211484
+<             ><span
+<                 class="os-divider"
+<               > </span
+1211491a1211489,1211491
+>             ><span
+>                 class="os-divider"
+>               > </span
+1211944,1211946d1211943
+<             ><span
+<                 class="os-divider"
+<               > </span
+1211950a1211948,1211950
+>             ><span
+>                 class="os-divider"
+>               > </span
+1212109,1212111d1212108
+<             ><span
+<                 class="os-divider"
+<               > </span
+1212115a1212113,1212115
+>             ><span
+>                 class="os-divider"
+>               > </span
+1212278,1212280d1212277
+<             ><span
+<                 class="os-divider"
+<               > </span
+1212284a1212282,1212284
+>             ><span
+>                 class="os-divider"
+>               > </span
+1224944,1224946d1224943
+<             ><span
+<                 class="os-divider"
+<               > </span
+1224950a1224948,1224950
+>             ><span
+>                 class="os-divider"
+>               > </span
+1224989,1224991d1224988
+<             ><span
+<                 class="os-divider"
+<               > </span
+1224995a1224993,1224995
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225022,1225024d1225021
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225028a1225026,1225028
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225091,1225093d1225090
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225097a1225095,1225097
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225128,1225130d1225127
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225134a1225132,1225134
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225213,1225215d1225212
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225219a1225217,1225219
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225286,1225288d1225285
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225292a1225290,1225292
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225351,1225353d1225350
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225357a1225355,1225357
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225422,1225424d1225421
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225428a1225426,1225428
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225487,1225489d1225486
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225493a1225491,1225493
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225552,1225554d1225551
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225558a1225556,1225558
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225571,1225573d1225570
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225577a1225575,1225577
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225620,1225622d1225619
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225626a1225624,1225626
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225701,1225703d1225700
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225707a1225705,1225707
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225798,1225800d1225797
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225804a1225802,1225804
+>             ><span
+>                 class="os-divider"
+>               > </span
+1225855,1225857d1225854
+<             ><span
+<                 class="os-divider"
+<               > </span
+1225861a1225859,1225861
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226088,1226090d1226087
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226094a1226092,1226094
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226217,1226219d1226216
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226223a1226221,1226223
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226306,1226308d1226305
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226312a1226310,1226312
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226411,1226413d1226410
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226417a1226415,1226417
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226456,1226458d1226455
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226462a1226460,1226462
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226493,1226495d1226492
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226499a1226497,1226499
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226512,1226514d1226511
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226518a1226516,1226518
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226531,1226533d1226530
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226537a1226535,1226537
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226550,1226552d1226549
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226556a1226554,1226556
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226659,1226661d1226658
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226665a1226663,1226665
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226760,1226762d1226759
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226766a1226764,1226766
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226845,1226847d1226844
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226851a1226849,1226851
+>             ><span
+>                 class="os-divider"
+>               > </span
+1226934,1226936d1226933
+<             ><span
+<                 class="os-divider"
+<               > </span
+1226940a1226938,1226940
+>             ><span
+>                 class="os-divider"
+>               > </span
+1227059,1227061d1227058
+<             ><span
+<                 class="os-divider"
+<               > </span
+1227065a1227063,1227065
+>             ><span
+>                 class="os-divider"
+>               > </span
+1227104,1227106d1227103
+<             ><span
+<                 class="os-divider"
+<               > </span
+1227110a1227108,1227110
+>             ><span
+>                 class="os-divider"
+>               > </span
+1227149,1227151d1227148
+<             ><span
+<                 class="os-divider"
+<               > </span
+1227155a1227153,1227155
+>             ><span
+>                 class="os-divider"
+>               > </span
+1227198,1227200d1227197
+<             ><span
+<                 class="os-divider"
+<               > </span
+1227204a1227202,1227204
+>             ><span
+>                 class="os-divider"
+>               > </span
+1227369,1227371d1227368
+<             ><span
+<                 class="os-divider"
+<               > </span
+1227375a1227373,1227375
+>             ><span
+>                 class="os-divider"
+>               > </span
+1227638,1227640d1227637
+<             ><span
+<                 class="os-divider"
+<               > </span
+1227644a1227642,1227644
+>             ><span
+>                 class="os-divider"
+>               > </span
+1227695,1227697d1227694
+<             ><span
+<                 class="os-divider"
+<               > </span
+1227701a1227699,1227701
+>             ><span
+>                 class="os-divider"
+>               > </span
+1227808,1227810d1227807
+<             ><span
+<                 class="os-divider"
+<               > </span
+1227814a1227812,1227814
+>             ><span
+>                 class="os-divider"
+>               > </span
+1227945,1227947d1227944
+<             ><span
+<                 class="os-divider"
+<               > </span
+1227951a1227949,1227951
+>             ><span
+>                 class="os-divider"
+>               > </span
+1228110,1228112d1228109
+<             ><span
+<                 class="os-divider"
+<               > </span
+1228116a1228114,1228116
+>             ><span
+>                 class="os-divider"
+>               > </span
+1228199,1228201d1228198
+<             ><span
+<                 class="os-divider"
+<               > </span
+1228205a1228203,1228205
+>             ><span
+>                 class="os-divider"
+>               > </span
+1228236,1228238d1228235
+<             ><span
+<                 class="os-divider"
+<               > </span
+1228242a1228240,1228242
+>             ><span
+>                 class="os-divider"
+>               > </span
+1228357,1228359d1228356
+<             ><span
+<                 class="os-divider"
+<               > </span
+1228363a1228361,1228363
+>             ><span
+>                 class="os-divider"
+>               > </span
+1228474,1228476d1228473
+<             ><span
+<                 class="os-divider"
+<               > </span
+1228480a1228478,1228480
+>             ><span
+>                 class="os-divider"
+>               > </span
+1228575,1228577d1228574
+<             ><span
+<                 class="os-divider"
+<               > </span
+1228581a1228579,1228581
+>             ><span
+>                 class="os-divider"
+>               > </span
+1228704,1228706d1228703
+<             ><span
+<                 class="os-divider"
+<               > </span
+1228710a1228708,1228710
+>             ><span
+>                 class="os-divider"
+>               > </span
+1228801,1228803d1228800
+<             ><span
+<                 class="os-divider"
+<               > </span
+1228807a1228805,1228807
+>             ><span
+>                 class="os-divider"
+>               > </span
+1228918,1228920d1228917
+<             ><span
+<                 class="os-divider"
+<               > </span
+1228924a1228922,1228924
+>             ><span
+>                 class="os-divider"
+>               > </span
+1228963,1228965d1228962
+<             ><span
+<                 class="os-divider"
+<               > </span
+1228969a1228967,1228969
+>             ><span
+>                 class="os-divider"
+>               > </span
+1229096,1229098d1229095
+<             ><span
+<                 class="os-divider"
+<               > </span
+1229102a1229100,1229102
+>             ><span
+>                 class="os-divider"
+>               > </span
+1229173,1229175d1229172
+<             ><span
+<                 class="os-divider"
+<               > </span
+1229179a1229177,1229179
+>             ><span
+>                 class="os-divider"
+>               > </span
+1229290,1229292d1229289
+<             ><span
+<                 class="os-divider"
+<               > </span
+1229296a1229294,1229296
+>             ><span
+>                 class="os-divider"
+>               > </span
+1229309,1229311d1229308
+<             ><span
+<                 class="os-divider"
+<               > </span
+1229315a1229313,1229315
+>             ><span
+>                 class="os-divider"
+>               > </span
+1229406,1229408d1229405
+<             ><span
+<                 class="os-divider"
+<               > </span
+1229412a1229410,1229412
+>             ><span
+>                 class="os-divider"
+>               > </span
+1229471,1229473d1229470
+<             ><span
+<                 class="os-divider"
+<               > </span
+1229477a1229475,1229477
+>             ><span
+>                 class="os-divider"
+>               > </span
+1229584,1229586d1229583
+<             ><span
+<                 class="os-divider"
+<               > </span
+1229590a1229588,1229590
+>             ><span
+>                 class="os-divider"
+>               > </span
+1252638,1252640d1252637
+<             ><span
+<                 class="os-divider"
+<               > </span
+1252644a1252642,1252644
+>             ><span
+>                 class="os-divider"
+>               > </span
+1252703,1252705d1252702
+<             ><span
+<                 class="os-divider"
+<               > </span
+1252709a1252707,1252709
+>             ><span
+>                 class="os-divider"
+>               > </span
+1252748,1252750d1252747
+<             ><span
+<                 class="os-divider"
+<               > </span
+1252754a1252752,1252754
+>             ><span
+>                 class="os-divider"
+>               > </span
+1252805,1252807d1252804
+<             ><span
+<                 class="os-divider"
+<               > </span
+1252811a1252809,1252811
+>             ><span
+>                 class="os-divider"
+>               > </span
+1252850,1252852d1252849
+<             ><span
+<                 class="os-divider"
+<               > </span
+1252856a1252854,1252856
+>             ><span
+>                 class="os-divider"
+>               > </span
+1252963,1252965d1252962
+<             ><span
+<                 class="os-divider"
+<               > </span
+1252969a1252967,1252969
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253044,1253046d1253043
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253050a1253048,1253050
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253117,1253119d1253116
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253123a1253121,1253123
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253202,1253204d1253201
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253208a1253206,1253208
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253285,1253287d1253284
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253291a1253289,1253291
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253346,1253348d1253345
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253352a1253350,1253352
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253365,1253367d1253364
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253371a1253369,1253371
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253452,1253454d1253451
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253458a1253456,1253458
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253563,1253565d1253562
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253569a1253567,1253569
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253608,1253610d1253607
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253614a1253612,1253614
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253665,1253667d1253664
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253671a1253669,1253671
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253738,1253740d1253737
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253744a1253742,1253744
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253823,1253825d1253822
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253829a1253827,1253829
+>             ><span
+>                 class="os-divider"
+>               > </span
+1253960,1253962d1253959
+<             ><span
+<                 class="os-divider"
+<               > </span
+1253966a1253964,1253966
+>             ><span
+>                 class="os-divider"
+>               > </span
+1254033,1254035d1254032
+<             ><span
+<                 class="os-divider"
+<               > </span
+1254039a1254037,1254039
+>             ><span
+>                 class="os-divider"
+>               > </span
+1254100,1254102d1254099
+<             ><span
+<                 class="os-divider"
+<               > </span
+1254106a1254104,1254106
+>             ><span
+>                 class="os-divider"
+>               > </span
+1254467,1254469d1254466
+<             ><span
+<                 class="os-divider"
+<               > </span
+1254473a1254471,1254473
+>             ><span
+>                 class="os-divider"
+>               > </span
+1254742,1254744d1254741
+<             ><span
+<                 class="os-divider"
+<               > </span
+1254748a1254746,1254748
+>             ><span
+>                 class="os-divider"
+>               > </span
+1254783,1254785d1254782
+<             ><span
+<                 class="os-divider"
+<               > </span
+1254789a1254787,1254789
+>             ><span
+>                 class="os-divider"
+>               > </span
+1254828,1254830d1254827
+<             ><span
+<                 class="os-divider"
+<               > </span
+1254834a1254832,1254834
+>             ><span
+>                 class="os-divider"
+>               > </span
+1254873,1254875d1254872
+<             ><span
+<                 class="os-divider"
+<               > </span
+1254879a1254877,1254879
+>             ><span
+>                 class="os-divider"
+>               > </span
+1255052,1255054d1255051
+<             ><span
+<                 class="os-divider"
+<               > </span
+1255058a1255056,1255058
+>             ><span
+>                 class="os-divider"
+>               > </span
+1255087,1255089d1255086
+<             ><span
+<                 class="os-divider"
+<               > </span
+1255093a1255091,1255093
+>             ><span
+>                 class="os-divider"
+>               > </span
+1255122,1255124d1255121
+<             ><span
+<                 class="os-divider"
+<               > </span
+1255128a1255126,1255128
+>             ><span
+>                 class="os-divider"
+>               > </span
+1255179,1255181d1255178
+<             ><span
+<                 class="os-divider"
+<               > </span
+1255185a1255183,1255185
+>             ><span
+>                 class="os-divider"
+>               > </span
+1255526,1255528d1255525
+<             ><span
+<                 class="os-divider"
+<               > </span
+1255532a1255530,1255532
+>             ><span
+>                 class="os-divider"
+>               > </span
+1255587,1255589d1255586
+<             ><span
+<                 class="os-divider"
+<               > </span
+1255593a1255591,1255593
+>             ><span
+>                 class="os-divider"
+>               > </span
+1255762,1255764d1255761
+<             ><span
+<                 class="os-divider"
+<               > </span
+1255768a1255766,1255768
+>             ><span
+>                 class="os-divider"
+>               > </span
+1255907,1255909d1255906
+<             ><span
+<                 class="os-divider"
+<               > </span
+1255913a1255911,1255913
+>             ><span
+>                 class="os-divider"
+>               > </span
+1255948,1255950d1255947
+<             ><span
+<                 class="os-divider"
+<               > </span
+1255954a1255952,1255954
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256091,1256093d1256090
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256097a1256095,1256097
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256184,1256186d1256183
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256190a1256188,1256190
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256217,1256219d1256216
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256223a1256221,1256223
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256250,1256252d1256249
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256256a1256254,1256256
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256359,1256361d1256358
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256365a1256363,1256365
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256392,1256394d1256391
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256398a1256396,1256398
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256425,1256427d1256424
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256431a1256429,1256431
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256458,1256460d1256457
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256464a1256462,1256464
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256491,1256493d1256490
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256497a1256495,1256497
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256570,1256572d1256569
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256576a1256574,1256576
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256647,1256649d1256646
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256653a1256651,1256653
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256724,1256726d1256723
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256730a1256728,1256730
+>             ><span
+>                 class="os-divider"
+>               > </span
+1256809,1256811d1256808
+<             ><span
+<                 class="os-divider"
+<               > </span
+1256815a1256813,1256815
+>             ><span
+>                 class="os-divider"
+>               > </span
+1257018,1257020d1257017
+<             ><span
+<                 class="os-divider"
+<               > </span
+1257024a1257022,1257024
+>             ><span
+>                 class="os-divider"
+>               > </span
+1257075,1257077d1257074
+<             ><span
+<                 class="os-divider"
+<               > </span
+1257081a1257079,1257081
+>             ><span
+>                 class="os-divider"
+>               > </span
+1257268,1257270d1257267
+<             ><span
+<                 class="os-divider"
+<               > </span
+1257274a1257272,1257274
+>             ><span
+>                 class="os-divider"
+>               > </span
+1257389,1257391d1257388
+<             ><span
+<                 class="os-divider"
+<               > </span
+1257395a1257393,1257395
+>             ><span
+>                 class="os-divider"
+>               > </span
+1257454,1257456d1257453
+<             ><span
+<                 class="os-divider"
+<               > </span
+1257460a1257458,1257460
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278493,1278495d1278492
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278499a1278497,1278499
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278648,1278650d1278647
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278654a1278652,1278654
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278667,1278669d1278666
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278673a1278671,1278673
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278686,1278688d1278685
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278692a1278690,1278692
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278726,1278728d1278725
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278732a1278730,1278732
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278804,1278806d1278803
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278810a1278808,1278810
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278849,1278851d1278848
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278855a1278853,1278855
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278868,1278870d1278867
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278874a1278872,1278874
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278887,1278889d1278886
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278893a1278891,1278893
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278906,1278908d1278905
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278912a1278910,1278912
+>             ><span
+>                 class="os-divider"
+>               > </span
+1278925,1278927d1278924
+<             ><span
+<                 class="os-divider"
+<               > </span
+1278931a1278929,1278931
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279160,1279162d1279159
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279166a1279164,1279166
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279179,1279181d1279178
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279185a1279183,1279185
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279198,1279200d1279197
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279204a1279202,1279204
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279259,1279261d1279258
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279265a1279263,1279265
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279308,1279310d1279307
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279314a1279312,1279314
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279401,1279403d1279400
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279407a1279405,1279407
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279498,1279500d1279497
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279504a1279502,1279504
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279607,1279609d1279606
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279613a1279611,1279613
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279656,1279658d1279655
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279662a1279660,1279662
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279675,1279677d1279674
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279681a1279679,1279681
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279728,1279730d1279727
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279734a1279732,1279734
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279891,1279893d1279890
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279897a1279895,1279897
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279910,1279912d1279909
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279916a1279914,1279916
+>             ><span
+>                 class="os-divider"
+>               > </span
+1279959,1279961d1279958
+<             ><span
+<                 class="os-divider"
+<               > </span
+1279965a1279963,1279965
+>             ><span
+>                 class="os-divider"
+>               > </span
+1280156,1280158d1280155
+<             ><span
+<                 class="os-divider"
+<               > </span
+1280162a1280160,1280162
+>             ><span
+>                 class="os-divider"
+>               > </span
+1280265,1280267d1280264
+<             ><span
+<                 class="os-divider"
+<               > </span
+1280271a1280269,1280271
+>             ><span
+>                 class="os-divider"
+>               > </span
+1280334,1280336d1280333
+<             ><span
+<                 class="os-divider"
+<               > </span
+1280340a1280338,1280340
+>             ><span
+>                 class="os-divider"
+>               > </span
+1280411,1280413d1280410
+<             ><span
+<                 class="os-divider"
+<               > </span
+1280417a1280415,1280417
+>             ><span
+>                 class="os-divider"
+>               > </span
+1280460,1280462d1280459
+<             ><span
+<                 class="os-divider"
+<               > </span
+1280466a1280464,1280466
+>             ><span
+>                 class="os-divider"
+>               > </span
+1280521,1280523d1280520
+<             ><span
+<                 class="os-divider"
+<               > </span
+1280527a1280525,1280527
+>             ><span
+>                 class="os-divider"
+>               > </span
+1280678,1280680d1280677
+<             ><span
+<                 class="os-divider"
+<               > </span
+1280684a1280682,1280684
+>             ><span
+>                 class="os-divider"
+>               > </span
+1280861,1280863d1280860
+<             ><span
+<                 class="os-divider"
+<               > </span
+1280867a1280865,1280867
+>             ><span
+>                 class="os-divider"
+>               > </span
+1280996,1280998d1280995
+<             ><span
+<                 class="os-divider"
+<               > </span
+1281002a1281000,1281002
+>             ><span
+>                 class="os-divider"
+>               > </span
+1281145,1281147d1281144
+<             ><span
+<                 class="os-divider"
+<               > </span
+1281151a1281149,1281151
+>             ><span
+>                 class="os-divider"
+>               > </span
+1281250,1281252d1281249
+<             ><span
+<                 class="os-divider"
+<               > </span
+1281256a1281254,1281256
+>             ><span
+>                 class="os-divider"
+>               > </span
+1281269,1281271d1281268
+<             ><span
+<                 class="os-divider"
+<               > </span
+1281275a1281273,1281275
+>             ><span
+>                 class="os-divider"
+>               > </span
+1281450,1281452d1281449
+<             ><span
+<                 class="os-divider"
+<               > </span
+1281456a1281454,1281456
+>             ><span
+>                 class="os-divider"
+>               > </span
+1281523,1281525d1281522
+<             ><span
+<                 class="os-divider"
+<               > </span
+1281529a1281527,1281529
+>             ><span
+>                 class="os-divider"
+>               > </span
+1281624,1281626d1281623
+<             ><span
+<                 class="os-divider"
+<               > </span
+1281630a1281628,1281630
+>             ><span
+>                 class="os-divider"
+>               > </span
+1281725,1281727d1281724
+<             ><span
+<                 class="os-divider"
+<               > </span
+1281731a1281729,1281731
+>             ><span
+>                 class="os-divider"
+>               > </span
+1281814,1281816d1281813
+<             ><span
+<                 class="os-divider"
+<               > </span
+1281820a1281818,1281820
+>             ><span
+>                 class="os-divider"
+>               > </span
+1281931,1281933d1281930
+<             ><span
+<                 class="os-divider"
+<               > </span
+1281937a1281935,1281937
+>             ><span
+>                 class="os-divider"
+>               > </span
+1282036,1282038d1282035
+<             ><span
+<                 class="os-divider"
+<               > </span
+1282042a1282040,1282042
+>             ><span
+>                 class="os-divider"
+>               > </span
+1318551,1318553d1318550
+<             ><span
+<                 class="os-divider"
+<               > </span
+1318557a1318555,1318557
+>             ><span
+>                 class="os-divider"
+>               > </span
+1318590,1318592d1318589
+<             ><span
+<                 class="os-divider"
+<               > </span
+1318596a1318594,1318596
+>             ><span
+>                 class="os-divider"
+>               > </span
+1318641,1318643d1318640
+<             ><span
+<                 class="os-divider"
+<               > </span
+1318647a1318645,1318647
+>             ><span
+>                 class="os-divider"
+>               > </span
+1318696,1318698d1318695
+<             ><span
+<                 class="os-divider"
+<               > </span
+1318702a1318700,1318702
+>             ><span
+>                 class="os-divider"
+>               > </span
+1318743,1318745d1318742
+<             ><span
+<                 class="os-divider"
+<               > </span
+1318749a1318747,1318749
+>             ><span
+>                 class="os-divider"
+>               > </span
+1318790,1318792d1318789
+<             ><span
+<                 class="os-divider"
+<               > </span
+1318796a1318794,1318796
+>             ><span
+>                 class="os-divider"
+>               > </span
+1318835,1318837d1318834
+<             ><span
+<                 class="os-divider"
+<               > </span
+1318841a1318839,1318841
+>             ><span
+>                 class="os-divider"
+>               > </span
+1318878,1318880d1318877
+<             ><span
+<                 class="os-divider"
+<               > </span
+1318884a1318882,1318884
+>             ><span
+>                 class="os-divider"
+>               > </span
+1318921,1318923d1318920
+<             ><span
+<                 class="os-divider"
+<               > </span
+1318927a1318925,1318927
+>             ><span
+>                 class="os-divider"
+>               > </span
+1318976,1318978d1318975
+<             ><span
+<                 class="os-divider"
+<               > </span
+1318982a1318980,1318982
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319019,1319021d1319018
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319025a1319023,1319025
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319074,1319076d1319073
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319080a1319078,1319080
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319117,1319119d1319116
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319123a1319121,1319123
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319160,1319162d1319159
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319166a1319164,1319166
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319215,1319217d1319214
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319221a1319219,1319221
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319262,1319264d1319261
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319268a1319266,1319268
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319455,1319457d1319454
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319461a1319459,1319461
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319544,1319546d1319543
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319550a1319548,1319550
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319589,1319591d1319588
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319595a1319593,1319595
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319634,1319636d1319633
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319640a1319638,1319640
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319731,1319733d1319730
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319737a1319735,1319737
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319772,1319774d1319771
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319778a1319776,1319778
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319825,1319827d1319824
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319831a1319829,1319831
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319866,1319868d1319865
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319872a1319870,1319872
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319899,1319901d1319898
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319905a1319903,1319905
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319936,1319938d1319935
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319942a1319940,1319942
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319973,1319975d1319972
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319979a1319977,1319979
+>             ><span
+>                 class="os-divider"
+>               > </span
+1319992,1319994d1319991
+<             ><span
+<                 class="os-divider"
+<               > </span
+1319998a1319996,1319998
+>             ><span
+>                 class="os-divider"
+>               > </span
+1320079,1320081d1320078
+<             ><span
+<                 class="os-divider"
+<               > </span
+1320085a1320083,1320085
+>             ><span
+>                 class="os-divider"
+>               > </span
+1320140,1320142d1320139
+<             ><span
+<                 class="os-divider"
+<               > </span
+1320146a1320144,1320146
+>             ><span
+>                 class="os-divider"
+>               > </span
+1320229,1320231d1320228
+<             ><span
+<                 class="os-divider"
+<               > </span
+1320235a1320233,1320235
+>             ><span
+>                 class="os-divider"
+>               > </span
+1320310,1320312d1320309
+<             ><span
+<                 class="os-divider"
+<               > </span
+1320316a1320314,1320316
+>             ><span
+>                 class="os-divider"
+>               > </span
+1320387,1320389d1320386
+<             ><span
+<                 class="os-divider"
+<               > </span
+1320393a1320391,1320393
+>             ><span
+>                 class="os-divider"
+>               > </span
+1320438,1320440d1320437
+<             ><span
+<                 class="os-divider"
+<               > </span
+1320444a1320442,1320444
+>             ><span
+>                 class="os-divider"
+>               > </span
+1320749,1320751d1320748
+<             ><span
+<                 class="os-divider"
+<               > </span
+1320755a1320753,1320755
+>             ><span
+>                 class="os-divider"
+>               > </span
+1320922,1320924d1320921
+<             ><span
+<                 class="os-divider"
+<               > </span
+1320928a1320926,1320928
+>             ><span
+>                 class="os-divider"
+>               > </span
+1320975,1320977d1320974
+<             ><span
+<                 class="os-divider"
+<               > </span
+1320981a1320979,1320981
+>             ><span
+>                 class="os-divider"
+>               > </span
+1321290,1321292d1321289
+<             ><span
+<                 class="os-divider"
+<               > </span
+1321296a1321294,1321296
+>             ><span
+>                 class="os-divider"
+>               > </span
+1321431,1321433d1321430
+<             ><span
+<                 class="os-divider"
+<               > </span
+1321437a1321435,1321437
+>             ><span
+>                 class="os-divider"
+>               > </span
+1321778,1321780d1321777
+<             ><span
+<                 class="os-divider"
+<               > </span
+1321784a1321782,1321784
+>             ><span
+>                 class="os-divider"
+>               > </span
+1321943,1321945d1321942
+<             ><span
+<                 class="os-divider"
+<               > </span
+1321949a1321947,1321949
+>             ><span
+>                 class="os-divider"
+>               > </span
+1322030,1322032d1322029
+<             ><span
+<                 class="os-divider"
+<               > </span
+1322036a1322034,1322036
+>             ><span
+>                 class="os-divider"
+>               > </span
+1322145,1322147d1322144
+<             ><span
+<                 class="os-divider"
+<               > </span
+1322151a1322149,1322151
+>             ><span
+>                 class="os-divider"
+>               > </span
+1322182,1322184d1322181
+<             ><span
+<                 class="os-divider"
+<               > </span
+1322188a1322186,1322188
+>             ><span
+>                 class="os-divider"
+>               > </span
+1322233,1322235d1322232
+<             ><span
+<                 class="os-divider"
+<               > </span
+1322239a1322237,1322239
+>             ><span
+>                 class="os-divider"
+>               > </span
+1322288,1322290d1322287
+<             ><span
+<                 class="os-divider"
+<               > </span
+1322294a1322292,1322294
+>             ><span
+>                 class="os-divider"
+>               > </span
+1322751,1322753d1322750
+<             ><span
+<                 class="os-divider"
+<               > </span
+1322757a1322755,1322757
+>             ><span
+>                 class="os-divider"
+>               > </span
+1323038,1323040d1323037
+<             ><span
+<                 class="os-divider"
+<               > </span
+1323044a1323042,1323044
+>             ><span
+>                 class="os-divider"
+>               > </span
+1323385,1323387d1323384
+<             ><span
+<                 class="os-divider"
+<               > </span
+1323391a1323389,1323391
+>             ><span
+>                 class="os-divider"
+>               > </span
+1323708,1323710d1323707
+<             ><span
+<                 class="os-divider"
+<               > </span
+1323714a1323712,1323714
+>             ><span
+>                 class="os-divider"
+>               > </span

--- a/recipes/books/_common-stuff.scss
+++ b/recipes/books/_common-stuff.scss
@@ -21,6 +21,9 @@ $Config_PartType_Figure_CaptionContent  : (os-title-label: "Figure ", os-number:
 $Config_PartType_Figure_CaptionContentAp: (os-title-label: "Figure ", os-number: counter(appendix, upper-alpha) counter(figure), os-divider: " "); //TODO: Make a counter for both chapter and appendix, and automate the switch between standard and upper alpha counting?
 $Config_PartType_Figure_CaptionContentPr: (os-title-label: "Figure ", os-number: counter(figure), os-divider: " ");
 
+$Config_ContentExercise_TitleContentOrder : (os-title-label : "Exercise ", os-number : counter(exerciseMaybeInContent));
+$Config_ContentExercise_TitleContentApOrder : (os-title-label : "Exercise ", os-number : counter(exerciseMaybeInContent));
+
 $Config_ContentExercise_TitleContent : (os-number : counter(exerciseMaybeInContent), os-title-label : "Exercise ");
 $Config_ContentSolution_TitleContent : null; // It seems that this is null for all books
 $Config_ContentExercise_TitleContentAp : (os-number : counter(exerciseMaybeInContent), os-title-label : "Exercise ");

--- a/recipes/books/_common-stuff.scss
+++ b/recipes/books/_common-stuff.scss
@@ -28,7 +28,10 @@ $Config_ContentSolution_TitleContentAp : null; // It seems that this is null for
 
 
 //global exercises numbering. There is a whitespace in the divider
+
+$Config_exerciseTitleContentOrder: (os-number: counter(exercise), os-divider: ". ");
 $Config_exerciseTitleContent: (os-divider: ". ", os-number: counter(exercise));
+
 
 $Config_addSolutionHeader: ();
 

--- a/recipes/books/_generator.scss
+++ b/recipes/books/_generator.scss
@@ -492,8 +492,13 @@
   @include modify_chapterAutoID();
   @include count_countExercisesInContentButNotInExample(exerciseMaybeInContent);
   // This has to run before number_numberEOCExercises because its selector is more general than the EOC selector
-  @include number_numberContentExercises($Config_ContentExercise_TitleContent, $Config_ContentSolution_TitleContent,
+  @if release-flag-enabled(exercise-label-order) {
+    @include number_numberContentExercises($Config_ContentExercise_TitleContentOrder, $Config_ContentSolution_TitleContent,
+                                         $Config_ContentExercise_TitleContentApOrder, $Config_ContentSolution_TitleContentAp);
+  } @else {
+    @include number_numberContentExercises($Config_ContentExercise_TitleContent, $Config_ContentSolution_TitleContent,
                                          $Config_ContentExercise_TitleContentAp, $Config_ContentSolution_TitleContentAp);
+  }
 
   $resetAt: map-get($Config_SetTableCaption, resetAt);
   @if $resetAt == moduleReset {

--- a/recipes/books/_release.scss
+++ b/recipes/books/_release.scss
@@ -144,5 +144,9 @@ $RELEASE_FLAGS: (
     "ap-physics",
     "calculus"),
 
+  exercise-label-order: enable-for(
+    "calculus"
+  ),
+
   //toc-comp-page-linking: enable-for("intro-business")        // this needs to be reworked to work see https://github.com/Connexions/cnx-easybake/issues/97
 );

--- a/recipes/books/calculus/_config.scss
+++ b/recipes/books/calculus/_config.scss
@@ -135,7 +135,7 @@ $_equationTitleContent     : (os-number: counter(chapter) "." counter(equation))
 $Config_PartType_Table_CaptionContent: (os-title-label: "Table ", os-number: counter(chapter) "." counter(table), os-divider: ' ');
 $Config_PartType_Figure_CaptionContent: (os-title-label: "Figure ", os-number: counter(chapter) "." counter(figure), os-divider: ' ');
 
-$Config_ContentExercise_TitleContent: ();
+$Config_ContentExercise_TitleContentOrder: ();
 
 $Config_PartType_Example: (moveTo: $AREA_NONE, titleContent: $_exampleTitleContent, solutionTitleContent: $_exampleSolutionTitleContent);
 $Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, hasSolutions: true, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $_exerciseTitleContent);

--- a/recipes/books/calculus/_config.scss
+++ b/recipes/books/calculus/_config.scss
@@ -62,7 +62,7 @@ $Config_ChapterCompositePages: (
     (className: "review-exercises", moveSolutionTo: $AREA_EOB, clusterBy: $CLUSTER_NONE, hasSolutions: true, name: "Chapter Review Exercises"),
 );
 
-$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContent, );
+$Config_PartType_Exercise: (moveTo: $AREA_EOC, resetAt: $RESET_CHAPTER, numberAt: $NUMBER_BEFORE_MOVE, titleContent: $Config_exerciseTitleContentOrder, );
 
 $Config_BookCompositePages: (
   (className: "solutions", clusterBy: $CLUSTER_SECTION, compoundComposite: true, moveSolutionsTo: $AREA_EOB, name: "Answer Key"),
@@ -125,7 +125,7 @@ $Config_Notes: (
 
 $_exampleTitleContent: (os-title-label: "Example ", os-number: counter(chapter) "." counter(example), os-divider: " ");
 $_exampleSolutionTitleContent: (os-title-label: "Solution ");
-$_exerciseTitleContent     : (os-divider: ". ", os-number: counter(exerciseMaybeInContent));
+$_exerciseTitleContent     : (os-number: counter(exerciseMaybeInContent), os-divider: ". ");
 $_equationTitleContent     : (os-number: counter(chapter) "." counter(equation));
 
 /*==========================================================

--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -471,7 +471,10 @@
           content: pending(equationNum)
         }
       } @else {
-        @include utils_title($numberedEquation);
+        @include utils_title($numberedEquation, bEquationLabel);
+        &:deferred {
+          content: pending(bEquationLabel) content();
+        }
       }
     }
   }

--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -43,27 +43,66 @@
 /// This has to run before number_numberEOCExercises because its selector is more general
 /// @group number
 @mixin number_numberContentExercises($exerciseTitleContent, $solutionTitleContent, $exerciseTitleContentAp, $solutionTitleContentAp) {
-  [data-type="chapter"] [data-type="page"] [data-type="exercise"]:not(.unnumbered) {
-    @if $exerciseTitleContent {
-      [data-type="problem"] {
-        @include utils_title($exerciseTitleContent);
+  @if release-flag-enabled(exercise-label-order) {
+    [data-type="chapter"] [data-type="page"] [data-type="exercise"]:not(.unnumbered) {
+      @if $exerciseTitleContent {
+        [data-type="problem"] {
+          @include utils_title($exerciseTitleContent, bContentExerciseLabel);
+          &:deferred {
+            content: pending(bContentExerciseLabel) content();
+          }
+        }
+      }
+      @if $solutionTitleContent {
+        [data-type="solution"] {
+          @include utils_title($solutionTitleContent, bContentSolutionLabel);
+          &:deferred {
+            content: pending(bContentSolutionLabel) content();
+          }
+        }
       }
     }
-    @if $solutionTitleContent {
-      [data-type="solution"] {
-        @include utils_title($solutionTitleContent);
+    .appendix [data-type="exercise"]:not(.unnumbered) {
+      @if $exerciseTitleContentAp {
+        [data-type="problem"] {
+          @include utils_title($exerciseTitleContentAp, bContentApExerciseLabel);
+          &:deferred {
+            content: pending(bContentApExerciseLabel) content();
+          }
+        }
+      }
+      @if $solutionTitleContentAp {
+        [data-type="solution"] {
+          @include utils_title($solutionTitleContentAp, bContentApSolutionLabel);
+          &:deferred {
+            content: pending(bContentApSolutionLabel) content();
+          }
+        }
       }
     }
-  }
-  .appendix [data-type="exercise"]:not(.unnumbered) {
-    @if $exerciseTitleContentAp {
-      [data-type="problem"] {
-        @include utils_title($exerciseTitleContentAp);
+  } @else {
+    [data-type="chapter"] [data-type="page"] [data-type="exercise"]:not(.unnumbered) {
+      @if $exerciseTitleContent {
+        [data-type="problem"] {
+          @include utils_title($exerciseTitleContent);
+        }
+      }
+      @if $solutionTitleContent {
+        [data-type="solution"] {
+          @include utils_title($solutionTitleContent);
+        }
       }
     }
-    @if $solutionTitleContentAp {
-      [data-type="solution"] {
-        @include utils_title($solutionTitleContentAp);
+    .appendix [data-type="exercise"]:not(.unnumbered) {
+      @if $exerciseTitleContentAp {
+        [data-type="problem"] {
+          @include utils_title($exerciseTitleContentAp);
+        }
+      }
+      @if $solutionTitleContentAp {
+        [data-type="solution"] {
+          @include utils_title($solutionTitleContentAp);
+        }
       }
     }
   }

--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -166,8 +166,17 @@
       move-to: trash;
     }
     @if $hasSolutions {
-      [data-type="solution"] {
-        @include utils_title($solutionTitleContent)
+      @if release-flag-enabled(exercise-label-order) {
+        [data-type="solution"] {
+          @include utils_title($solutionTitleContent, bNoteSolutionLabel);
+          &:deferred {
+            content: pending(bNoteSolutionLabel) content();
+          }
+        }
+      } @else {
+        [data-type="solution"] {
+          @include utils_title($solutionTitleContent)
+        }
       }
     }
     &::after {

--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -72,24 +72,54 @@
 //EOS composite pages must be created before this runs
 @mixin number_numberEOSExercises($exerciseTitleContent, $solutionTitleContent) {
   .os-eos [data-type="exercise"] {
-    [data-type="problem"] {
-      @include utils_title($exerciseTitleContent);
-    }
-    [data-type="solution"] {
-      @include utils_title($exerciseTitleContent);
-    }
+    @if release-flag-enabled(exercise-label-order) {
+      [data-type="problem"] {
+        @include utils_title($exerciseTitleContent, bEOSExerciseLabel);
+        &:deferred {
+          content: pending(bEOSExerciseLabel) content();
+        }
+      }
+      [data-type="solution"] {
+        @include utils_title($exerciseTitleContent, bEOSSolutionLabel);
+        &:deferred {
+          content: pending(bEOSSolutionLabel) content();
+        }
+      }
+    } @else {
+      [data-type="problem"] {
+        @include utils_title($exerciseTitleContent);
+      }
+      [data-type="solution"] {
+        @include utils_title($exerciseTitleContent);
+      }
+    }    
   }
 }
 
 //EOC composite pages must be created before this runs
 @mixin number_numberEOCExercises($exerciseTitleContent, $solutionTitleContent) {
   .os-eoc [data-type="exercise"] {
-    [data-type="problem"] {
-      @include utils_title($exerciseTitleContent);
-    }
-    [data-type="solution"] {
-      @include utils_title($exerciseTitleContent);
-    }
+    @if release-flag-enabled(exercise-label-order) {
+      [data-type="problem"] {
+        @include utils_title($exerciseTitleContent, bEOCExerciseLabel);
+        &:deferred {
+          content: pending(bEOCExerciseLabel) content();
+        }
+      }
+      [data-type="solution"] {
+        @include utils_title($exerciseTitleContent, bEOCSolutionLabel);
+        &:deferred {
+          content: pending(bEOCSolutionLabel) content();
+        }
+      }
+    } @else {
+      [data-type="problem"] {
+        @include utils_title($exerciseTitleContent);
+      }
+      [data-type="solution"] {
+        @include utils_title($exerciseTitleContent);
+      }
+    }    
   }
 }
 

--- a/recipes/output/calculus.css
+++ b/recipes/output/calculus.css
@@ -1173,23 +1173,33 @@
 
 :pass(6) .os-eos [data-type="exercise"] [data-type="problem"]::before {
   container: span;
-  content: ". ";
-  class: os-divider; }
+  content: counter(exerciseMaybeInContent);
+  class: os-number;
+  move-to: bEOSExerciseLabel; }
 
 :pass(6) .os-eos [data-type="exercise"] [data-type="problem"]::before {
   container: span;
+  content: ". ";
+  class: os-divider;
+  move-to: bEOSExerciseLabel; }
+
+:pass(6) .os-eos [data-type="exercise"] [data-type="problem"]:deferred {
+  content: pending(bEOSExerciseLabel) content(); }
+
+:pass(6) .os-eos [data-type="exercise"] [data-type="solution"]::before {
+  container: span;
   content: counter(exerciseMaybeInContent);
-  class: os-number; }
+  class: os-number;
+  move-to: bEOSSolutionLabel; }
 
 :pass(6) .os-eos [data-type="exercise"] [data-type="solution"]::before {
   container: span;
   content: ". ";
-  class: os-divider; }
+  class: os-divider;
+  move-to: bEOSSolutionLabel; }
 
-:pass(6) .os-eos [data-type="exercise"] [data-type="solution"]::before {
-  container: span;
-  content: counter(exerciseMaybeInContent);
-  class: os-number; }
+:pass(6) .os-eos [data-type="exercise"] [data-type="solution"]:deferred {
+  content: pending(bEOSSolutionLabel) content(); }
 
 :pass(6) [data-type="chapter"], :pass(6) .appendix {
   counter-reset: exerciseMaybeInContent; }
@@ -1199,23 +1209,33 @@
 
 :pass(6) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
-  content: ". ";
-  class: os-divider; }
+  content: counter(exerciseMaybeInContent);
+  class: os-number;
+  move-to: bEOCExerciseLabel; }
 
 :pass(6) .os-eoc [data-type="exercise"] [data-type="problem"]::before {
   container: span;
+  content: ". ";
+  class: os-divider;
+  move-to: bEOCExerciseLabel; }
+
+:pass(6) .os-eoc [data-type="exercise"] [data-type="problem"]:deferred {
+  content: pending(bEOCExerciseLabel) content(); }
+
+:pass(6) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
+  container: span;
   content: counter(exerciseMaybeInContent);
-  class: os-number; }
+  class: os-number;
+  move-to: bEOCSolutionLabel; }
 
 :pass(6) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
   container: span;
   content: ". ";
-  class: os-divider; }
+  class: os-divider;
+  move-to: bEOCSolutionLabel; }
 
-:pass(6) .os-eoc [data-type="exercise"] [data-type="solution"]::before {
-  container: span;
-  content: counter(exerciseMaybeInContent);
-  class: os-number; }
+:pass(6) .os-eoc [data-type="exercise"] [data-type="solution"]:deferred {
+  content: pending(bEOCSolutionLabel) content(); }
 
 :pass(7) body {
   counter-reset: exerciseAll; }

--- a/recipes/output/calculus.css
+++ b/recipes/output/calculus.css
@@ -912,12 +912,17 @@
 :pass(3) [data-type="note"].checkpoint [data-type="solution"]::before {
   container: span;
   content: counter(chapter) "." counter(checkpoint);
-  class: os-number; }
+  class: os-number;
+  move-to: bNoteSolutionLabel; }
 
 :pass(3) [data-type="note"].checkpoint [data-type="solution"]::before {
   container: span;
   content: " ";
-  class: os-divider; }
+  class: os-divider;
+  move-to: bNoteSolutionLabel; }
+
+:pass(3) [data-type="note"].checkpoint [data-type="solution"]:deferred {
+  content: pending(bNoteSolutionLabel) content(); }
 
 :pass(3) [data-type="note"].checkpoint::after {
   container: div;

--- a/recipes/output/calculus.css
+++ b/recipes/output/calculus.css
@@ -1587,15 +1587,23 @@
 :pass(9) :not([data-type="example"]) > [data-type="exercise"]:not(.unnumbered) {
   counter-increment: exerciseMaybeInContent; }
 
-:pass(9) .appendix [data-type="exercise"]:not(.unnumbered) [data-type="problem"]::before {
-  container: span;
-  content: counter(exerciseMaybeInContent);
-  class: os-number; }
+:pass(9) [data-type="chapter"] [data-type="page"] [data-type="exercise"]:not(.unnumbered) [data-type="problem"]:deferred {
+  content: pending(bContentExerciseLabel) content(); }
 
 :pass(9) .appendix [data-type="exercise"]:not(.unnumbered) [data-type="problem"]::before {
   container: span;
   content: "Exercise ";
-  class: os-title-label; }
+  class: os-title-label;
+  move-to: bContentApExerciseLabel; }
+
+:pass(9) .appendix [data-type="exercise"]:not(.unnumbered) [data-type="problem"]::before {
+  container: span;
+  content: counter(exerciseMaybeInContent);
+  class: os-number;
+  move-to: bContentApExerciseLabel; }
+
+:pass(9) .appendix [data-type="exercise"]:not(.unnumbered) [data-type="problem"]:deferred {
+  content: pending(bContentApExerciseLabel) content(); }
 
 :pass(9) [data-type="chapter"], :pass(9) .appendix, :pass(9) .preface {
   counter-reset: table; }


### PR DESCRIPTION
In **common-stuff** and **config** files parts of exercises label are defined in oposite order then they are displayed. 

For example:

![image](https://user-images.githubusercontent.com/40228854/61228747-281c0980-a727-11e9-8c91-208f9ac5f92a.png)

![image](https://user-images.githubusercontent.com/40228854/61228767-366a2580-a727-11e9-8ae7-3627078b7075.png)

We want to define spans forming a label in the same order they are displaying.