### PR TITLE
Make sure cnx-recipes use the latest dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 requests
 pytest
 PyICU==1.9.8
+rhaptos.cnxmlutils>=1.7.0
 cnx-easybake>=1.2.5
+cnx-transforms>=1.2.0
 nebuchadnezzar>=9.1.0


### PR DESCRIPTION
We recently made changes to the transforms code so cnx-recipes need to
be updated so the transforms and bake-book results are accurate.