### PR TITLE
Fix CSS desync post-bake

### DIFF
--- a/script/bake-book
+++ b/script/bake-book
@@ -83,7 +83,7 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   fi
 
   if [ -f "${style_file}" ]; then
-    ln -f "${style_file}" "./data/${book_name}"
+    ln -sfr "${style_file}" "./data/${book_name}"
     do_progress_quiet "Adding style file ${style_file}" \
       sed -i "s%<\\/head>%<link rel=\"stylesheet\" type=\"text/css\" href=\"$(basename "${style_file}")\" />&%" "${baked_file}"
   elif [ -n "${STYLE}" ] || [ -n "${style_name}" ]; then


### PR DESCRIPTION
The other fix would sync CSS only every bake. This will create a symlink, which will sync through building styles.