### PR TITLE
Allow pdf docker-compose service to find styles/icons

### DIFF
--- a/script/bake-book
+++ b/script/bake-book
@@ -83,7 +83,7 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   fi
 
   if [ -f "${style_file}" ]; then
-    ln -sfr "${style_file}" "./data/${book_name}"
+    ln -sfr "${style_file}" "./data/${book_name}/$(basename "${style_file}")"
     do_progress_quiet "Adding style file ${style_file}" \
       sed -i "s%<\\/head>%<link rel=\"stylesheet\" type=\"text/css\" href=\"$(basename "${style_file}")\" />&%" "${baked_file}"
   elif [ -n "${STYLE}" ] || [ -n "${style_name}" ]; then

--- a/script/build-pdf
+++ b/script/build-pdf
@@ -46,6 +46,12 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   style_file="${STYLE:-./styles/output/${style_name}-pdf.css}"
   output_file="${book_dir}/collection.pdf"
 
+  local_book_dir="./data/${book_name}"
+  style_path="${local_book_dir}/$(basename "${style_file}")"
+  style_file_cp="${local_book_dir}/${book_name}.css"
+  style_path_for_prince="${book_dir}/${book_name}.css"
+  readarray -d '' icon_files < <(find ./styles/designs/*/resources -type f -print0)
+
   if [ -f "${mathified_file}" ]; then
     input_file="${mathified_file}"
   else
@@ -54,13 +60,24 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
 
   style_flag=()
   if [ -f "${style_file}" ]; then
-    style_flag=('--style' "${book_dir}/$(basename "${style_file}")")
-    cp "${style_file}" "./data/${book_name}"
+    if [ -h "${style_path}" ]; then : ; else
+      ln -sfr "${style_file}" "${style_path}"
+    fi
+    # Symlink will not persist in the container, so we will copy it
+    cp -f "${style_path}" "${style_file_cp}"
+    style_flag=('--style' "${style_path_for_prince}")
   elif [ -n "${STYLE}" ] || [ -n "${style_name}" ]; then
     _say "${c_red}WARNING${c_none} style not found: ${style_file}"
   else
     _say "${c_red}WARNING${c_none} style name missing in books.txt"
   fi
+
+  mkdir -p "${local_book_dir}/icons"
+  for icon_file in "${icon_files[@]}"; do
+    cp --remove-destination "${icon_file}" "${local_book_dir}/icons"
+  done
+  sed -Ei 's|../../styles/designs/.*/resources|icons|g' "${style_file_cp}"
+
 
   # Run princexml as root to bypass permission issues:
   # The data directory belongs to root, the default user on the princexml image


### PR DESCRIPTION
Hopefully once this gets merged, devs and QA should be able to use `docker-compose run --rm build-pdf [book]` and get consistent results.