### PR TITLE
Fix bakery commands unable to access style file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     environment:
       NEB_CONFIG: /etc/neb/config
     volumes:
-      - "${HOST_PWD:-.}/data:/out"
+      - "${HOST_PWD:-.}:/out"
       - "${HOST_PWD:-.}/config/neb-config:/etc/neb/config:ro"
 
   assemble-book:
@@ -67,7 +67,7 @@ services:
     build: https://github.com/openstax/mathify.git
     image: openstax/mathify
     volumes:
-      - "${HOST_PWD:-.}/data:/out"
+      - "${HOST_PWD:-.}:/out"
 
   build-pdf:
     build: .
@@ -87,7 +87,7 @@ services:
     build: https://github.com/openstax/docker-princexml.git
     image: openstax/princexml
     volumes:
-      - "${HOST_PWD:-.}/data:/out"
+      - "${HOST_PWD:-.}:/out"
 
   command:
     build: .

--- a/script/assemble-book
+++ b/script/assemble-book
@@ -78,15 +78,15 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   # Allow user to override the hostname
   host_name=${HOST:-${host_name}}
 
-  book_dir="${OUTPUT_DIR:-./data}/${book_name}"
+  book_dir="${OUTPUT_DIR:-./}/data/${book_name}"
   raw_dir="${book_dir}/raw"
   raw_file="${book_dir}/collection.assembled.xhtml"
 
-  rm -rf "${raw_file/$OUTPUT_DIR/.\/data}"
+  rm -rf "${raw_file/$OUTPUT_DIR/.\/}"
 
   do_progress "Creating HTML file for ${book_name}" \
     docker-compose run --rm neb /bin/bash -c "pip install -U -r requirements/main.txt && neb assemble \"${raw_dir}\" \"${book_dir}\" && chown -R $(stat -c '%u:%g' ./data) \"${book_dir}\""
 
-  _say "${c_green}Assemble is Done.${c_none} File is available at ${raw_file/$OUTPUT_DIR/$HOST_PWD\/data}"
+  _say "${c_green}Assemble is Done.${c_none} File is available at ${raw_file/$OUTPUT_DIR/$HOST_PWD}"
 
 done

--- a/script/bake-book
+++ b/script/bake-book
@@ -83,9 +83,8 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   fi
 
   if [ -f "${style_file}" ]; then
-    ln -sfr "${style_file}" "./data/${book_name}/$(basename "${style_file}")"
     do_progress_quiet "Adding style file ${style_file}" \
-      sed -i "s%<\\/head>%<link rel=\"stylesheet\" type=\"text/css\" href=\"$(basename "${style_file}")\" />&%" "${baked_file}"
+      sed -i "s%<\\/head>%<link rel=\"stylesheet\" type=\"text/css\" href=\"../../${style_file}\" />&%" "${baked_file}"
   elif [ -n "${STYLE}" ] || [ -n "${style_name}" ]; then
     _say "${c_red}WARNING${c_none} style not found: ${style_file}"
   else

--- a/script/build-pdf
+++ b/script/build-pdf
@@ -40,17 +40,11 @@ fi
 for book_config in "${BOOK_CONFIGS[@]}"; do
   read -r book_name _ _ _ _ _ style_name <<< "${book_config}"
 
-  book_dir="${OUTPUT_DIR:-./data}/${book_name}"
+  book_dir="${OUTPUT_DIR:-./}/data/${book_name}"
   mathified_file="${book_dir}/collection.mathified.xhtml"
   baked_file="${book_dir}/collection.baked.xhtml"
   style_file="${STYLE:-./styles/output/${style_name}-pdf.css}"
   output_file="${book_dir}/collection.pdf"
-
-  local_book_dir="./data/${book_name}"
-  style_path="${local_book_dir}/$(basename "${style_file}")"
-  style_file_cp="${local_book_dir}/${book_name}.css"
-  style_path_for_prince="${book_dir}/${book_name}.css"
-  readarray -d '' icon_files < <(find ./styles/designs/*/resources -type f -print0)
 
   if [ -f "${mathified_file}" ]; then
     input_file="${mathified_file}"
@@ -60,24 +54,12 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
 
   style_flag=()
   if [ -f "${style_file}" ]; then
-    if [ -h "${style_path}" ]; then : ; else
-      ln -sfr "${style_file}" "${style_path}"
-    fi
-    # Symlink will not persist in the container, so we will copy it
-    cp -f "${style_path}" "${style_file_cp}"
-    style_flag=('--style' "${style_path_for_prince}")
+    style_flag=('--style' "${OUTPUT_DIR:-./}/${style_file}")
   elif [ -n "${STYLE}" ] || [ -n "${style_name}" ]; then
     _say "${c_red}WARNING${c_none} style not found: ${style_file}"
   else
     _say "${c_red}WARNING${c_none} style name missing in books.txt"
   fi
-
-  mkdir -p "${local_book_dir}/icons"
-  for icon_file in "${icon_files[@]}"; do
-    cp --remove-destination "${icon_file}" "${local_book_dir}/icons"
-  done
-  sed -Ei 's|../../styles/designs/.*/resources|icons|g' "${style_file_cp}"
-
 
   # Run princexml as root to bypass permission issues:
   # The data directory belongs to root, the default user on the princexml image
@@ -88,5 +70,5 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
 
   docker-compose run --rm -u root pdf chown -R "$(stat -c '%u:%g' ./data)" "${book_dir}"
 
-  _say "Output in ${output_file/$OUTPUT_DIR/$HOST_PWD\/data}"
+  _say "Output in ${output_file/$OUTPUT_DIR/$HOST_PWD}"
 done

--- a/script/fetch-book
+++ b/script/fetch-book
@@ -82,11 +82,11 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   # Allow user to override the hostname
   host_name=${HOST:-${host_name}}
 
-  book_dir="${OUTPUT_DIR:-./data}/${book_name}"
+  book_dir="${OUTPUT_DIR:-./}/data/${book_name}"
   raw_dir="${book_dir}/raw"
 
-  mkdir -p "${book_dir/$OUTPUT_DIR/.\/data}"
-  rm -rf "${raw_dir/$OUTPUT_DIR/.\/data}"
+  mkdir -p "${book_dir/$OUTPUT_DIR/.\/}"
+  rm -rf "${raw_dir/$OUTPUT_DIR/.\/}"
 
   neb_get_flag=''
   if $with_resources; then
@@ -96,6 +96,6 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   do_progress "Fetching ${book_name} from ${host_name}" \
     docker-compose run --rm neb /bin/bash -c "neb get ${neb_get_flag} -d \"${raw_dir}\" \"${host_name}\" \"${colid}\" '' && chown -R $(stat -c '%u:%g' ./data) \"${book_dir}\""
 
-  _say "${c_green}Fetch is Done.${c_none} The book is in ${raw_dir/$OUTPUT_DIR/$HOST_PWD\/data}"
+  _say "${c_green}Fetch is Done.${c_none} The book is in ${raw_dir/$OUTPUT_DIR/$HOST_PWD}"
 
 done

--- a/script/mathify-book
+++ b/script/mathify-book
@@ -51,7 +51,7 @@ fi
 for book_config in "${BOOK_CONFIGS[@]}"; do
   read -r book_config_name _ <<< "${book_config}"
 
-  book_dir="${OUTPUT_DIR:-./data}/${book_config_name}"
+  book_dir="${OUTPUT_DIR:-./}/data/${book_config_name}"
   baked_file="${book_dir}/collection.baked.xhtml"
   mathified_file="${book_dir}/collection.mathified.xhtml"
   math_format=${MATH_FORMAT:-svg}
@@ -64,5 +64,5 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   do_progress "Converting math in ${baked_file} to ${math_format}" \
     docker-compose run --rm mathify /bin/bash -c "node --max_old_space_size=\$(free -m | awk '/Mem:/ { print \$2 }') typeset/start -i \"${baked_file}\" -o \"${mathified_file}\" -f \"${math_format}\" && cp -r node_modules/mathjax \"${book_dir}\" && chown -R $(stat -c '%u:%g' ./data) \"${book_dir}\""
 
-  _say "Output is available at ${mathified_file/$OUTPUT_DIR/$HOST_PWD\/data}"
+  _say "Output is available at ${mathified_file/$OUTPUT_DIR/$HOST_PWD}"
 done


### PR DESCRIPTION
For commands that have their own docker containers, we mount only the
`data/` directory because it has the books.  We either hardlinked or
symlinked the style css when it's needed.  Turns out, this isn't quite
enough, especially with resource files.

The simplest way to fix this is to just mount the whole working
directory so all docker containers have access to everything inside the
cnx-recipes repo.  That way, there's no need to copy things into the
`data/` directory.

---

An alternative way to fix #1208