### PR TITLE
Add twine check on travis

### DIFF
--- a/script/ci
+++ b/script/ci
@@ -16,3 +16,9 @@ if [[ -n "${has_changes}" ]]; then
   git diff -- ':!/styles/output/_web-styles.json'
   exit 1
 fi
+
+if [[ "${CI}" == "true" ]]; then
+  pip install twine
+  python setup.py bdist_wheel --universal
+  twine check dist/*
+fi


### PR DESCRIPTION
To avoid tagging and then getting rejected by pypi, we're running twine
check on travis so it will catch all the errors before we upload to
pypi.

See https://github.com/openstax/cnx/issues/663 (unable to connect this PR to the issue)