### PR TITLE
Fix build-recipes call to use book name inside bake-book

### DIFF
--- a/script/bake-book
+++ b/script/bake-book
@@ -56,7 +56,7 @@ for book_config in "${BOOK_CONFIGS[@]}"; do
   read -r book_name recipe_name _ _ _ _ _ <<< "${book_config}"
 
   do_progress_quiet "Compiling CSS file" \
-    ./script/build-recipes "${recipe_name}"
+    ./script/build-recipes "${book_name}"
 
   raw_file="./data/${book_name}/collection.assembled.xhtml"
   baked_file="./data/${book_name}/collection.baked.xhtml"


### PR DESCRIPTION
When running `bake-book` for `hsphysics`, the recipe `hs-physics.css`
was not compiled before baking the book.

We were passing the recipe name to `build-recipes` inside `bake-book`
but actually `build-recipes` is expecting a book name.  Most of our
books have the same name as the recipe so we didn't notice this bug.

So change the argument to `build-recipes` inside `bake-book` to book
name and it works.