### PR TITLE
u-physics: subtitled-examples flag

### DIFF
--- a/recipes/mixins/_modify.scss
+++ b/recipes/mixins/_modify.scss
@@ -425,7 +425,7 @@
 
 @mixin modify_exampleTitle() {
   [data-type="example"] {
-    .body > [data-type="title"] {
+    .body > [data-type="title"], p > [data-type="title"] {
       container: h4
     }
   }

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -1507,7 +1507,7 @@
 :pass(3) a[data-type="footnote-number"] > sup {
   content: counter(footnoteLinks); }
 
-:pass(3) [data-type="example"] .body > [data-type="title"] {
+:pass(3) [data-type="example"] .body > [data-type="title"], :pass(3) [data-type="example"] p > [data-type="title"] {
   container: h4; }
 
 :pass(3) body {

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -587,7 +587,7 @@
 :pass(3) a[data-type="footnote-number"] > sup {
   content: counter(footnoteLinks); }
 
-:pass(3) [data-type="example"] .body > [data-type="title"] {
+:pass(3) [data-type="example"] .body > [data-type="title"], :pass(3) [data-type="example"] p > [data-type="title"] {
   container: h4; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {

--- a/recipes/output/biology.css
+++ b/recipes/output/biology.css
@@ -1024,7 +1024,7 @@
 :pass(3) a[data-type="footnote-number"] > sup {
   content: counter(footnoteLinks); }
 
-:pass(3) [data-type="example"] .body > [data-type="title"] {
+:pass(3) [data-type="example"] .body > [data-type="title"], :pass(3) [data-type="example"] p > [data-type="title"] {
   container: h4; }
 
 :pass(3) body {

--- a/recipes/output/hs-physics.css
+++ b/recipes/output/hs-physics.css
@@ -1438,7 +1438,7 @@
 :pass(3) a[data-type="footnote-number"] > sup {
   content: counter(footnoteLinks); }
 
-:pass(3) [data-type="example"] .body > [data-type="title"] {
+:pass(3) [data-type="example"] .body > [data-type="title"], :pass(3) [data-type="example"] p > [data-type="title"] {
   container: h4; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -626,7 +626,7 @@
 :pass(3) a[data-type="footnote-number"] > sup {
   content: counter(footnoteLinks); }
 
-:pass(3) [data-type="example"] .body > [data-type="title"] {
+:pass(3) [data-type="example"] .body > [data-type="title"], :pass(3) [data-type="example"] p > [data-type="title"] {
   container: h4; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -820,7 +820,7 @@
 :pass(3) a[data-type="footnote-number"] > sup {
   content: counter(footnoteLinks); }
 
-:pass(3) [data-type="example"] .body > [data-type="title"] {
+:pass(3) [data-type="example"] .body > [data-type="title"], :pass(3) [data-type="example"] p > [data-type="title"] {
   container: h4; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {


### PR DESCRIPTION
Issue: https://github.com/openstax/cnx-recipes/issues/1965
After enabling all feature flags for University Physics during the tests it appeared that the last flag `subtitled-examples` doesn't work correctly in this book (the example subtitle isn't moved to h4 tag as it should be): 
![image](https://user-images.githubusercontent.com/55203598/75567572-0bcca300-5a52-11ea-8112-7cd998abf588.png)
