### PR TITLE
Add chemistry af and concepts biology to template

### DIFF
--- a/books.txt
+++ b/books.txt
@@ -75,11 +75,11 @@ declare -x -r RECIPE_DESC=(
 BOOK_CONFIGS=(
 # "_example                   _example                           example-uuid                           col12345   easyvm5.cnx.org       mixins/                   example"
   "chemistry-2e               chemistry                          7fccc9cf-9b71-44f6-800b-f9457fd64335   col26069   katalyst01.cnx.org    mixins/                   template1"
-  "chemistry-atoms-first-2e   chemistry                          d9b85ee6-c57f-4861-8208-5ddf261e9c5f   col26488   katalyst01.cnx.org    mixins"
+  "chemistry-atoms-first-2e   chemistry                          d9b85ee6-c57f-4861-8208-5ddf261e9c5f   col26488   katalyst01.cnx.org    mixins/                   template1"
   "anatomy                    anatomy                            14fb4ad7-39a1-4eee-ab6e-3ef2482e3e22   col11496   katalyst01.cnx.org    mixins/                   template1"
   "biology-2e                 biology                            8d50a0af-948b-4204-a71d-4826cba765b8   col24361   katalyst01.cnx.org    mixins/                   template1"
   "apbiology                  ap-biology                         6c322e32-9fb0-4c4d-a1d7-20c95c5c7af2   col12078   katalyst01.cnx.org    mixins/,books/biology     template1"
-  "concepts-biology           biology                            b3c1e1d2-839c-42b0-a314-e119a8aafbdd   col11487   katalyst01.cnx.org    mixins"
+  "concepts-biology           biology                            b3c1e1d2-839c-42b0-a314-e119a8aafbdd   col11487   katalyst01.cnx.org    mixins/                   template1"
   "microbiology               microbiology                       e42bd376-624b-4c0f-972f-e0c57998e765   col12087   katalyst01.cnx.org    mixins/                   template1"
   "physics                    physics                            031da8d3-b525-429c-80cf-6c8ed997733a   col11406   katalyst01.cnx.org    mixins/                   template1"
   "apphysics                  ap-physics                         8d04a686-d5e8-4798-a27d-c608e4d0e187   col11844   katalyst01.cnx.org    mixins/,books/physics/"


### PR DESCRIPTION
Add Chemistry AF and Concepts Biology permanently to template. 

When those books are baked on branch on which they are not added to template, it causes changes in `chemistry.css` and `biology.css` file respectively. 

So it's safer now to keep them always added to template to avoid mistakes.