### PR TITLE
remove doubled table caption config

### DIFF
--- a/recipes/books/physics/_config.scss
+++ b/recipes/books/physics/_config.scss
@@ -65,7 +65,6 @@ $_equationTitleContent       : (os-number: counter(chapter) "." counter(equation
 /*==========================================================
   PHYSICS CONFIG
 ==========================================================*/
-$Config_SetTableCaption : (captionType: $CAPTION_TABLE, defaultContainer: caption, hasCaption: false, hasTitle: true);
 $Config_SetFigureCaption: (captionType: $CAPTION_FIGURE, defaultContainer: figcaption, hasCaption: true, hasTitle: false);
 //If this method of setting the content of the label explicity becomes a problem,
 //try grabbing the numbering information from the element's header

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -1308,6 +1308,15 @@
   class: os-divider;
   move-to: bCaption; }
 
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered).top-titled thead tr:first-child {
+  string-set: TopTitleContent content();
+  move-to: trash; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered) caption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
 :pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered)::after {
   container: span;
   class: 'os-divider';
@@ -1325,10 +1334,15 @@
   content: pending(bCaption) pending(bCaptionTitle) pending(bCaptionDivider) pending(bCaptionContent);
   move-to: bCaptionContainer; }
 
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered).top-titled::after {
+  class: "os-table-title";
+  content: string(TopTitleContent);
+  move-to: tableTopTitle; }
+
 :pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered)::outside {
   class: os-table;
   container: div;
-  content: content() pending(bCaptionContainer); }
+  content: pending(tableTopTitle) content() pending(bCaptionContainer); }
 
 :pass(9) [data-type="chapter"] > table.unnumbered caption {
   move-to: trash; }
@@ -1354,6 +1368,12 @@
   class: os-divider;
   move-to: bCaption; }
 
+:pass(9) .appendix :not(table) > table:not(.unnumbered) caption,
+:pass(9) .appendix > table:not(.unnumbered) caption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
 :pass(9) .appendix :not(table) > table:not(.unnumbered)::after,
 :pass(9) .appendix > table:not(.unnumbered)::after {
   container: span;
@@ -1374,11 +1394,22 @@
   content: pending(bCaption) pending(bCaptionTitle) pending(bCaptionDivider) pending(bCaptionContent);
   move-to: bCaptionContainer; }
 
+:pass(9) .appendix :not(table) > table:not(.unnumbered).top-titled::after,
+:pass(9) .appendix > table:not(.unnumbered).top-titled::after {
+  class: "os-table-title";
+  content: string(TopTitleContent);
+  move-to: tableTopTitle; }
+
 :pass(9) .appendix :not(table) > table:not(.unnumbered)::outside,
 :pass(9) .appendix > table:not(.unnumbered)::outside {
   class: os-table;
   container: div;
-  content: content() pending(bCaptionContainer); }
+  content: pending(tableTopTitle) content() pending(bCaptionContainer); }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered).top-titled thead tr:first-child,
+:pass(9) .appendix > table:not(.unnumbered).top-titled thead tr:first-child {
+  string-set: TopTitleContent content();
+  move-to: trash; }
 
 :pass(9) .appendix > table.unnumbered caption {
   move-to: trash; }
@@ -1401,6 +1432,11 @@
   class: os-divider;
   move-to: bCaption; }
 
+:pass(9) .preface :not(table) > table:not(.unnumbered) caption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
 :pass(9) .preface :not(table) > table:not(.unnumbered)::after {
   container: span;
   class: 'os-divider';
@@ -1418,10 +1454,15 @@
   content: pending(bCaption) pending(bCaptionTitle) pending(bCaptionDivider) pending(bCaptionContent);
   move-to: bCaptionContainer; }
 
+:pass(9) .preface :not(table) > table:not(.unnumbered).top-titled::after {
+  class: "os-table-title";
+  content: string(TopTitleContent);
+  move-to: tableTopTitle; }
+
 :pass(9) .preface :not(table) > table:not(.unnumbered)::outside {
   class: os-table;
   container: div;
-  content: content() pending(bCaptionContainer); }
+  content: pending(tableTopTitle) content() pending(bCaptionContainer); }
 
 :pass(9) .preface > table.unnumbered caption {
   move-to: trash; }

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -1246,6 +1246,16 @@
   class: os-divider;
   move-to: bCaption; }
 
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered).top-titled thead tr:first-child th {
+  container: div;
+  class: "os-temporary-table-title";
+  move-to: tableTopTitle; }
+
+:pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered) caption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
 :pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered)::after {
   container: span;
   class: 'os-divider';
@@ -1266,7 +1276,7 @@
 :pass(9) [data-type="chapter"] :not(table) > table:not(.unnumbered)::outside {
   class: os-table;
   container: div;
-  content: content() pending(bCaptionContainer); }
+  content: pending(tableTopTitle) content() pending(bCaptionContainer); }
 
 :pass(9) [data-type="chapter"] > table.unnumbered caption {
   move-to: trash; }
@@ -1292,6 +1302,12 @@
   class: os-divider;
   move-to: bCaption; }
 
+:pass(9) .appendix :not(table) > table:not(.unnumbered) caption,
+:pass(9) .appendix > table:not(.unnumbered) caption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
 :pass(9) .appendix :not(table) > table:not(.unnumbered)::after,
 :pass(9) .appendix > table:not(.unnumbered)::after {
   container: span;
@@ -1316,7 +1332,13 @@
 :pass(9) .appendix > table:not(.unnumbered)::outside {
   class: os-table;
   container: div;
-  content: content() pending(bCaptionContainer); }
+  content: pending(tableTopTitle) content() pending(bCaptionContainer); }
+
+:pass(9) .appendix :not(table) > table:not(.unnumbered).top-titled thead tr:first-child th,
+:pass(9) .appendix > table:not(.unnumbered).top-titled thead tr:first-child th {
+  container: div;
+  class: "os-temporary-table-title";
+  move-to: tableTopTitle; }
 
 :pass(9) .appendix > table.unnumbered caption {
   move-to: trash; }
@@ -1339,6 +1361,11 @@
   class: os-divider;
   move-to: bCaption; }
 
+:pass(9) .preface :not(table) > table:not(.unnumbered) caption {
+  container: span;
+  class: "os-caption";
+  move-to: bCaptionContent; }
+
 :pass(9) .preface :not(table) > table:not(.unnumbered)::after {
   container: span;
   class: 'os-divider';
@@ -1359,7 +1386,7 @@
 :pass(9) .preface :not(table) > table:not(.unnumbered)::outside {
   class: os-table;
   container: div;
-  content: content() pending(bCaptionContainer); }
+  content: pending(tableTopTitle) content() pending(bCaptionContainer); }
 
 :pass(9) .preface > table.unnumbered caption {
   move-to: trash; }
@@ -1521,6 +1548,12 @@
 :pass(9) .appendix > section > section > [data-type="title"], :pass(9) .appendix > section > section [data-type="document-title"] {
   container: h3; }
 
+:pass(10) .os-table .top-titled thead tr:first-child {
+  move-to: trash; }
+
+:pass(10) .os-table .os-temporary-table-title::inside {
+  class: "os-table-title"; }
+
 :pass(10) .os-eoc [data-type="solution"] {
   move-to: trash; }
 
@@ -1554,6 +1587,15 @@
 :pass(10) [data-type="composite-page"] {
   counter-increment: composite-page;
   attr-id: "composite-page-" counter(composite-page); }
+
+:pass(11) .os-table .os-table-title {
+  move-to: tableFinalTitle; }
+
+:pass(11) .os-table .os-temporary-table-title {
+  move-to: trash; }
+
+:pass(11) .os-table::deferred {
+  content: pending(tableFinalTitle) content(); }
 
 :pass(11) div.os-eoc [data-type="cnx-archive-uri"],
 :pass(11) div.os-eob [data-type="cnx-archive-uri"] {


### PR DESCRIPTION
Issue: #2118
In this PR I'm only moving commit from this PR (which was approved): https://github.com/openstax/cnx-recipes/pull/2117, because it contains footnote changes (was created form g.g), which has been now removed form current g.g branch.