### PR TITLE
remove the old footnote format

### DIFF
--- a/recipes/mixins/_count.scss
+++ b/recipes/mixins/_count.scss
@@ -294,8 +294,7 @@
 @mixin count_footnotes($name) {
   @include _count(
     $name,
-    //first is old markup selector. the transforms code needed by the new selector is not being deployed until recipes are re-baked on REX
-    '[data-type="footnote-ref"], aside[role="doc-footnote"]',
+    'aside[role="doc-footnote"]',
     '[data-type="chapter"], .appendix'
   )
 }
@@ -314,8 +313,7 @@
 @mixin count_footnoteLinks($name) {
   @include _count(
     $name,
-    //first is old markup selector. the transforms code needed by the new selector is not being deployed until recipes are re-baked on REX
-    '[data-type="footnote-number"], a[role="doc-noteref"]',
+    'a[role="doc-noteref"]',
     '[data-type="chapter"], .appendix'
   )
 }

--- a/recipes/mixins/_number.scss
+++ b/recipes/mixins/_number.scss
@@ -483,22 +483,6 @@
 }
 
 @mixin number_footnotes($footnoteCounter, $footnoteLinkCounter) {
-  // Footnotes option 1 
-  li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-    content: counter($footnoteCounter);
-  }
-  sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-    content: counter($footnoteLinkCounter);
-  }
-  // Footnotes option 2
-  li > a[data-type="footnote-ref"] {
-    content: counter($footnoteCounter);
-  }
-  a[data-type="footnote-number"] > sup {
-    content: counter($footnoteLinkCounter);
-  }
-
-  ////the selectors above this (footnote options 1 and 2) are the old selectors. the transforms code needed by the new selector is not being deployed until recipes are re-baked on REX
   a[role="doc-noteref"] {
     content: counter($footnoteLinkCounter);
   }

--- a/recipes/output/accounting.css
+++ b/recipes/output/accounting.css
@@ -1080,26 +1080,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/american-government.css
+++ b/recipes/output/american-government.css
@@ -913,26 +913,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/anatomy.css
+++ b/recipes/output/anatomy.css
@@ -1056,26 +1056,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -1526,26 +1526,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/ap-history.css
+++ b/recipes/output/ap-history.css
@@ -610,26 +610,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -605,26 +605,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/astronomy.css
+++ b/recipes/output/astronomy.css
@@ -945,26 +945,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/biology.css
+++ b/recipes/output/biology.css
@@ -1043,26 +1043,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/business-ethics.css
+++ b/recipes/output/business-ethics.css
@@ -862,26 +862,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/calculus.css
+++ b/recipes/output/calculus.css
@@ -848,26 +848,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/chemistry.css
+++ b/recipes/output/chemistry.css
@@ -845,26 +845,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/college-success.css
+++ b/recipes/output/college-success.css
@@ -848,26 +848,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/dev-math.css
+++ b/recipes/output/dev-math.css
@@ -1030,26 +1030,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/economics.css
+++ b/recipes/output/economics.css
@@ -872,26 +872,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/entrepreneurship.css
+++ b/recipes/output/entrepreneurship.css
@@ -948,26 +948,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/history.css
+++ b/recipes/output/history.css
@@ -850,26 +850,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/hs-physics.css
+++ b/recipes/output/hs-physics.css
@@ -1457,26 +1457,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/intro-business.css
+++ b/recipes/output/intro-business.css
@@ -1233,26 +1233,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/microbiology.css
+++ b/recipes/output/microbiology.css
@@ -1114,26 +1114,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/physics.css
+++ b/recipes/output/physics.css
@@ -645,26 +645,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/pl-u-physics.css
+++ b/recipes/output/pl-u-physics.css
@@ -803,26 +803,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/precalculus.css
+++ b/recipes/output/precalculus.css
@@ -856,26 +856,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/principles-management.css
+++ b/recipes/output/principles-management.css
@@ -1305,26 +1305,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/psychology.css
+++ b/recipes/output/psychology.css
@@ -924,26 +924,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/sociology.css
+++ b/recipes/output/sociology.css
@@ -851,26 +851,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/statistics.css
+++ b/recipes/output/statistics.css
@@ -873,26 +873,14 @@ Formula Review page
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -839,26 +839,14 @@
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnotes; }
 
-:pass(3) [data-type="footnote-ref"], :pass(3) aside[role="doc-footnote"] {
+:pass(3) aside[role="doc-footnote"] {
   counter-increment: footnotes; }
 
 :pass(3) [data-type="chapter"], :pass(3) .appendix {
   counter-reset: footnoteLinks; }
 
-:pass(3) [data-type="footnote-number"], :pass(3) a[role="doc-noteref"] {
+:pass(3) a[role="doc-noteref"] {
   counter-increment: footnoteLinks; }
-
-:pass(3) li[data-type="footnote-ref"] > a[data-type="footnote-ref-link"] {
-  content: counter(footnotes); }
-
-:pass(3) sup[data-type="footnote-number"] > a[data-type="footnote-link"] {
-  content: counter(footnoteLinks); }
-
-:pass(3) li > a[data-type="footnote-ref"] {
-  content: counter(footnotes); }
-
-:pass(3) a[data-type="footnote-number"] > sup {
-  content: counter(footnoteLinks); }
 
 :pass(3) a[role="doc-noteref"] {
   content: counter(footnoteLinks); }


### PR DESCRIPTION
:broom: This completes the work in #2250 by removing the now-dead code.

This should be released once the book viewers all use the new footnote format.

refs #566