### PR TITLE
support unnumbered splashes

### DIFF
--- a/recipes/books/_generator.scss
+++ b/recipes/books/_generator.scss
@@ -704,6 +704,7 @@
   @include modify_wrapMathInPara();
   @include modify_tagExerciseWithFirstElementClass();
   @include modify_tagTableParentContainer();
+  @include compose_UnnumberedSplash();
 }
 :pass(14) {
   @include toc_navTOCUnwrap();

--- a/recipes/mixins/_compose.scss
+++ b/recipes/mixins/_compose.scss
@@ -1028,3 +1028,30 @@
     content: pending(ChapterOutline) content();
   }
 }
+
+//moves .splash.unnumbered into .os-figure.has-splash
+//moves splash caption into .os-caption-container
+//curently unnumbered splashes are only found in corn/coreq styled books, but we should support in all recipes
+@mixin compose_UnnumberedSplash {
+  [data-type="page"].introduction {
+    figure.splash.unnumbered {
+      move-to: splash;
+      figcaption {
+        class: "os-caption";
+        container: span;
+        move-to: os-caption;
+      }
+      &::after {
+        content: pending(os-caption);
+        move-to: splashCaption;
+        class: "os-caption-container";
+      }
+    }
+    &:deferred {
+      &::before {
+        class: "os-figure has-splash";
+        content: pending(splash) pending(splashCaption)
+      }
+    }
+  }
+}

--- a/recipes/output/accounting.css
+++ b/recipes/output/accounting.css
@@ -2685,6 +2685,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/american-government.css
+++ b/recipes/output/american-government.css
@@ -2347,6 +2347,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/anatomy.css
+++ b/recipes/output/anatomy.css
@@ -2278,6 +2278,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/ap-biology.css
+++ b/recipes/output/ap-biology.css
@@ -2890,6 +2890,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/ap-history.css
+++ b/recipes/output/ap-history.css
@@ -1510,6 +1510,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/ap-physics.css
+++ b/recipes/output/ap-physics.css
@@ -2153,6 +2153,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/astronomy.css
+++ b/recipes/output/astronomy.css
@@ -2421,6 +2421,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/biology.css
+++ b/recipes/output/biology.css
@@ -2212,6 +2212,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/business-ethics.css
+++ b/recipes/output/business-ethics.css
@@ -2309,6 +2309,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/calculus.css
+++ b/recipes/output/calculus.css
@@ -2493,6 +2493,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/chemistry.css
+++ b/recipes/output/chemistry.css
@@ -2356,6 +2356,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/college-physics.css
+++ b/recipes/output/college-physics.css
@@ -1731,6 +1731,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/college-success.css
+++ b/recipes/output/college-success.css
@@ -1762,6 +1762,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/dev-math.css
+++ b/recipes/output/dev-math.css
@@ -2747,6 +2747,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/economics.css
+++ b/recipes/output/economics.css
@@ -2304,6 +2304,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/entrepreneurship.css
+++ b/recipes/output/entrepreneurship.css
@@ -2355,6 +2355,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/history.css
+++ b/recipes/output/history.css
@@ -2191,6 +2191,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/hs-physics.css
+++ b/recipes/output/hs-physics.css
@@ -3187,6 +3187,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/intro-business.css
+++ b/recipes/output/intro-business.css
@@ -2545,6 +2545,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/microbiology.css
+++ b/recipes/output/microbiology.css
@@ -2604,6 +2604,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/pl-u-physics.css
+++ b/recipes/output/pl-u-physics.css
@@ -2789,6 +2789,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/precalculus-coreq.css
+++ b/recipes/output/precalculus-coreq.css
@@ -2750,6 +2750,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/precalculus.css
+++ b/recipes/output/precalculus.css
@@ -2523,6 +2523,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/principles-management.css
+++ b/recipes/output/principles-management.css
@@ -2591,6 +2591,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/psychology.css
+++ b/recipes/output/psychology.css
@@ -2061,6 +2061,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/sociology.css
+++ b/recipes/output/sociology.css
@@ -2049,6 +2049,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/statistics.css
+++ b/recipes/output/statistics.css
@@ -2225,6 +2225,21 @@ Formula Review page
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,

--- a/recipes/output/u-physics.css
+++ b/recipes/output/u-physics.css
@@ -2615,6 +2615,21 @@
   :pass(13) .os-table:deferred {
     class: attr(class) string(hasTable); }
 
+:pass(13) [data-type="page"].introduction figure.splash.unnumbered {
+  move-to: splash; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered figcaption {
+    class: "os-caption";
+    container: span;
+    move-to: os-caption; }
+  :pass(13) [data-type="page"].introduction figure.splash.unnumbered::after {
+    content: pending(os-caption);
+    move-to: splashCaption;
+    class: "os-caption-container"; }
+
+:pass(13) [data-type="page"].introduction:deferred::before {
+  class: "os-figure has-splash";
+  content: pending(splash) pending(splashCaption); }
+
 :pass(14) nav#toc li > a > h1 > span,
 :pass(14) nav#toc li > a > h2 > span,
 :pass(14) nav#toc li > a > h3 > span,


### PR DESCRIPTION
- moves .splash.unnumbered into .os-figure.has-splash
- moves splash caption for unnumbered splash into .os-caption-container
- curently unnumbered splashes are only found in corn/coreq styled books, but requested that support be added
- because the unnumbered class is not on splash images in any other books, I am not expecting if to affect the other books 


Link to content search: https://philschatz.com/bulk/#%7B%22q%22%3A%22.unnumbered%20.splash%22%7D
Issue: https://github.com/openstax/cnx-recipes/issues/2533