### PR TITLE
Pin node version for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.16.1'
       - uses: c-hive/gha-yarn-cache@v2
       - name : Install npm dependencies
         run: SKIP_MY_POSTINSTALL=true yarn install


### PR DESCRIPTION
GitHub Actions were failing. and it seems like the version of node changed, the yarn-cache action cached native bindings to the old node.

Node version is defined in multiple places:

- https://github.com/openstax/cnx-recipes/blob/master/.node-version
- https://github.com/openstax/richb-press/blob/main/Dockerfile.common#L121
- And in the ubuntu base image. (that one had 16 I think)


The GitHub Action uses gha-yarn-cache to install yarn so we looked in there to see if it installed node. It didn't, but it [hinted at how we could set the version of node ourselves](https://github.com/c-hive/gha-yarn-cache/blob/b76064412ccb54d95da722f48c096aa506765544/.github/workflows/build.yml#L17-L20)

Here's the error:

```
 /home/runner/.node-gyp/16.13.0/include/node/v8-internal.h:492:63: note: suggested alternative: ‘herror’
             !std::is_same<Data, std::remove_cv_t<T>>::value>::Perform(data);
                                                               ^~~~~~~
                                                               herror
binding.target.mk:133: recipe for target 'Release/obj.target/binding/src/binding.o' failed
make: *** [Release/obj.target/binding/src/binding.o] Error 1
make: Leaving directory '/home/runner/work/cnx-recipes/cnx-recipes/node_modules/node-sass/build'
gyp ERR! build error 
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/home/runner/work/cnx-recipes/cnx-recipes/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (node:events:390:28)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:290:12)
gyp ERR! System Linux 5.4.0-1063-azure
gyp ERR! command "/usr/local/bin/node" "/home/runner/work/cnx-recipes/cnx-recipes/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd /home/runner/work/cnx-recipes/cnx-recipes/node_modules/node-sass
gyp ERR! node -v v16.13.0
gyp ERR! node-gyp -v v3.8.0
```