### PR TITLE
add devcontainer for styles devs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+
+{ 
+    "name": "Styles Devcontainer",
+    "build": {
+        "dockerfile": "../Dockerfile",
+        "context": "..",
+    },
+    "workspaceMount": "source=${localWorkspaceFolder},target=/code,type=bind,consistency=default",
+    "workspaceFolder": "/code",
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash",
+    }
+}


### PR DESCRIPTION
To test out:

1. VSCode may give you a "reopen in container" button when it detects the devcontainer.json file
2. If not, click the green icon in the lower left corner of VSCode
<img width="132" alt="image" src="https://user-images.githubusercontent.com/26280712/146565619-0038c4b1-33d9-4925-a8fb-b255af2957ea.png">

Then select "Reopen in Container" from the menu at the top.

<img width="594" alt="image" src="https://user-images.githubusercontent.com/26280712/146565661-0d88c95a-9892-437a-bb97-98277e301563.png">

Try running a few scripts in the container, such as the build script for an individual style, or `./script/build-styles`