### PR TITLE
script for targeting which styles to recompile

### DIFF
--- a/script/build-impacted-styles
+++ b/script/build-impacted-styles
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+usage="script/build-impacted-styles <theme> <shape_name>"
+if [[ $# -lt 2 ]] ; then
+    echo "Not enough args"
+    echo $usage
+    exit 1
+fi
+
+cd "$(dirname "$0")/.." || exit 111
+source ./script/bootstrap || exit 111
+
+theme=$1
+shape_name=$2
+
+styles_root="./styles/books"
+output_dir="./styles/output"
+
+book_files=($(grep -R -l "$theme:::$shape_name" $styles_root))
+echo "Found ${#book_files[@]} files with this shape."
+
+PLATFORMS=(pdf)
+for i in "${!book_files[@]}"; do
+    sass_file=${book_files[i]}
+    style_name=$(cut -d / -f 4 <<< $sass_file)
+    for platform in "${PLATFORMS[@]}"; do
+        css_file="${output_dir}/${style_name}-${platform}.css"
+
+        PLATFORM="${platform}" do_progress "Generating ${css_file} $((i + 1))/${#book_files[@]}" \
+            node styles/build/build.js "${sass_file}" "${css_file}"
+    done
+done

--- a/script/build-impacted-styles
+++ b/script/build-impacted-styles
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-usage="script/build-impacted-styles <theme> <shape_name>"
-if [[ $# -lt 2 ]] ; then
+usage="script/build-impacted-styles <theme> <shape_name (optional)>"
+if [[ $# -lt 1 ]] ; then
     echo "Not enough args"
     echo $usage
     exit 1
@@ -16,8 +16,10 @@ shape_name=$2
 styles_root="./styles/books"
 output_dir="./styles/output"
 
-book_files=($(grep -R -l "$theme:::$shape_name" $styles_root))
-echo "Found ${#book_files[@]} files with this shape."
+search_string="$theme:::$shape_name"
+book_files=($(grep -R -l $search_string $styles_root))
+echo "Found ${#book_files[@]} files with instances of $search_string."
+echo `grep -R -l $search_string $styles_root`
 
 PLATFORMS=(pdf)
 for i in "${!book_files[@]}"; do


### PR DESCRIPTION
Use: `script/build-impacted-styles <theme> <shape_name>`

This will search `book.scss` files for occurrences of `theme:::shape_name` and only recompile those styles that call the given shape.

Example:

```bash
# Just theme
> ./script/build-impacted-styles cardboard
==> Activating Python virtualenv ... OK
==> Prepending nodenv node to beginning of PATH so native bindings compile against the right version of node
Found 10 files with instances of cardboard:::.
./styles/books/accounting/book.scss ./styles/books/astronomy/book.scss ./styles/books/bca/book.scss ./styles/books/business-ethics/book.scss ./styles/books/college-success/book.scss ./styles/books/computer-science/book.scss ./styles/books/entrepreneurship/book.scss ./styles/books/finance/book.scss ./styles/books/intro-business/book.scss ./styles/books/principles-management/book.scss
==> Generating ./styles/output/accounting-pdf.css 1/10
# ... etc ...
```

```bash
# Theme & shape
root@20f80f0760a3:/code# ./script/build-impacted-styles cardboard UnstyledTableShape
==> Activating Python virtualenv ... OK
==> Prepending nodenv node to beginning of PATH so native bindings compile against the right version of node
Found 3 files with instances of cardboard:::UnstyledTableShape.
./styles/books/accounting/book.scss ./styles/books/college-success/book.scss ./styles/books/computer-science/book.scss
==> Generating ./styles/output/accounting-pdf.css 1/3
# ... etc ...
```