### PR TITLE
style lists in problems on pages for corn

### DIFF
--- a/styles/design-settings/corn/parts/_lists-settings.scss
+++ b/styles/design-settings/corn/parts/_lists-settings.scss
@@ -20,7 +20,7 @@
 // Used for circled lists in Try It Notes and Examples in all of the corn theme books, in Statistics books, where the exercises and solutions are in one column and in College Algebra Coreq for Coreq Skills exercises which are in one column as well
 @include add_settings((
     ExercisesProblemLists: (
-        _selectors: ('[data-type="page"] > section:not(.os-eos) [data-type="problem"]'),
+        _selectors: ('[data-type="page"] > :not(.os-eos) [data-type="problem"]'),
         CircledListToken: (
             color: (_ref: 'colorMap:::circledListTokenColor'),
         ),

--- a/styles/output/calculus-pdf.css
+++ b/styles/output/calculus-pdf.css
@@ -1576,71 +1576,71 @@ a {
 .os-eob.os-solutions-container [data-type="solution"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ul:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ul:not(.circled):not(.os-stepwise) {
   margin-left: 16px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ul:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ul:not(.circled):not(.os-stepwise) {
   margin-left: 16px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-figure:first-child img {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-figure:first-child img {
   vertical-align: top;
   display: inline; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-table:first-child table {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-table:first-child table {
   vertical-align: top;
   display: inline-table; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > p > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > p > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled {
   list-style-type: none;
   display: inline;
   padding-right: 0.5rem; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li {
   padding-right: 1.4rem;
   display: inline-block; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > [data-type="media"]:nth-child(2) img {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > [data-type="media"]:nth-child(2) img {
   vertical-align: top;
   display: inline; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > os.table:nth-child(2) table {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > os.table:nth-child(2) table {
   vertical-align: top;
   display: inline-table; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul[data-labeled-item="true"] > li > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul[data-labeled-item="true"] > li > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
 [data-type="page"] [data-type="solution"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {

--- a/styles/output/contemporary-math-pdf.css
+++ b/styles/output/contemporary-math-pdf.css
@@ -2010,71 +2010,71 @@ a {
 .os-eob.os-solutions-container [data-type="solution"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ul:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ul:not(.circled):not(.os-stepwise) {
   margin-left: 16px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ul:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ul:not(.circled):not(.os-stepwise) {
   margin-left: 16px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-figure:first-child img {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-figure:first-child img {
   vertical-align: top;
   display: inline; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-table:first-child table {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-table:first-child table {
   vertical-align: top;
   display: inline-table; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > p > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > p > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled {
   list-style-type: none;
   display: inline;
   padding-right: 0.5rem; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li {
   padding-right: 1.4rem;
   display: inline-block; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > [data-type="media"]:nth-child(2) img {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > [data-type="media"]:nth-child(2) img {
   vertical-align: top;
   display: inline; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > os.table:nth-child(2) table {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > os.table:nth-child(2) table {
   vertical-align: top;
   display: inline-table; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul[data-labeled-item="true"] > li > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul[data-labeled-item="true"] > li > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
 [data-type="page"] [data-type="solution"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {

--- a/styles/output/dev-math-pdf.css
+++ b/styles/output/dev-math-pdf.css
@@ -2101,71 +2101,71 @@ a[role="doc-noteref"] {
 .os-eob.os-solutions-container [data-type="solution"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ul:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ul:not(.circled):not(.os-stepwise) {
   margin-left: 16px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ul:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ul:not(.circled):not(.os-stepwise) {
   margin-left: 16px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-figure:first-child img {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-figure:first-child img {
   vertical-align: top;
   display: inline; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-table:first-child table {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-table:first-child table {
   vertical-align: top;
   display: inline-table; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > p > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > p > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled {
   list-style-type: none;
   display: inline;
   padding-right: 0.5rem; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li {
   padding-right: 1.4rem;
   display: inline-block; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > [data-type="media"]:nth-child(2) img {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > [data-type="media"]:nth-child(2) img {
   vertical-align: top;
   display: inline; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > os.table:nth-child(2) table {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > os.table:nth-child(2) table {
   vertical-align: top;
   display: inline-table; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul[data-labeled-item="true"] > li > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul[data-labeled-item="true"] > li > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
 [data-type="page"] [data-type="solution"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {

--- a/styles/output/precalculus-coreq-pdf.css
+++ b/styles/output/precalculus-coreq-pdf.css
@@ -1788,71 +1788,71 @@ section.coreq-skills > section.learning-objectives > ul > li {
 .os-eob.os-solution-container [data-type="solution"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ul:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ul:not(.circled):not(.os-stepwise) {
   margin-left: 16px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ul:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ul:not(.circled):not(.os-stepwise) {
   margin-left: 16px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-figure:first-child img {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-figure:first-child img {
   vertical-align: top;
   display: inline; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-table:first-child table {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-table:first-child table {
   vertical-align: top;
   display: inline-table; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > p > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > p > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled {
   list-style-type: none;
   display: inline;
   padding-right: 0.5rem; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li {
   padding-right: 1.4rem;
   display: inline-block; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > [data-type="media"]:nth-child(2) img {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > [data-type="media"]:nth-child(2) img {
   vertical-align: top;
   display: inline; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > os.table:nth-child(2) table {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > os.table:nth-child(2) table {
   vertical-align: top;
   display: inline-table; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul[data-labeled-item="true"] > li > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul[data-labeled-item="true"] > li > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
 [data-type="page"] [data-type="solution"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {

--- a/styles/output/precalculus-pdf.css
+++ b/styles/output/precalculus-pdf.css
@@ -1834,71 +1834,71 @@ a[role="doc-noteref"] {
 .os-eob.os-solution-container [data-type="solution"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ul:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ul:not(.circled):not(.os-stepwise) {
   margin-left: 16px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) > li > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ul:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ul:not(.circled):not(.os-stepwise) {
   margin-left: 16px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ol:not(.circled):not(.os-stepwise) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > ol:not(.circled):not(.os-stepwise) {
   margin-left: 24px; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-figure:first-child img {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-figure:first-child img {
   vertical-align: top;
   display: inline; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-table:first-child table {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ol:not(.circled):not(.os-stepwise) > li > .os-table:first-child table {
   vertical-align: top;
   display: inline-table; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > p > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > p > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled {
   list-style-type: none;
   display: inline;
   padding-right: 0.5rem; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li {
   padding-right: 1.4rem;
   display: inline-block; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > [data-type="media"]:nth-child(2) img {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > [data-type="media"]:nth-child(2) img {
   vertical-align: top;
   display: inline; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > .circled > li > os.table:nth-child(2) table {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > .circled > li > os.table:nth-child(2) table {
   vertical-align: top;
   display: inline-table; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > ul[data-labeled-item="true"] > li > .token {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > ul[data-labeled-item="true"] > li > .token {
   color: #1E7E91;
   font-size: 1.728rem;
   margin-right: 8px;
   line-height: 1.5rem;
   vertical-align: middle; }
 
-[data-type="page"] > section:not(.os-eos) [data-type="problem"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
+[data-type="page"] > :not(.os-eos) [data-type="problem"] > div > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {
   margin-left: 24px; }
 
 [data-type="page"] [data-type="solution"] > div > ul:not(.circled):not(.os-stepwise):not([data-labeled-item="true"]) {


### PR DESCRIPTION
#4383

![image](https://user-images.githubusercontent.com/26280712/150816832-074f545a-001d-4feb-8612-6529d802d4ec.png)

Adjusted the filtering on the style rule so that 1. an exercise on a page but not contained within a `section` element will be styled (the above case), but 2. exercises on `.os-eos` pages are still skipped over.