### PR TITLE
create styles for pl-economics

### DIFF
--- a/books.txt
+++ b/books.txt
@@ -103,6 +103,7 @@ BOOK_CONFIGS=(
   "microbiology               microbiology                       e42bd376-624b-4c0f-972f-e0c57998e765   col12087   cnx.org               mixins/                   carnival"
   "microeconap-2e             economics                          636cbfd9-4e37-4575-83ab-9dec9029ca4e   col23750   cnx.org               mixins/"
   "organizational-behavior    principles-management              2d941ab9-ac5b-4eb8-b21c-965d36a4f296   col29124   cnx.org               mixins"
+  "pl-microecon               pl-economics                                                                                                                         cosmos"               
   "pl-psychology              pl-psychology                      f3824852-403f-472f-84f2-1c04c0a17033   col32565   cnx.org               mixins/                   cosmos"
   "pl-u-physics-vol1          pl-u-physics                       4eaa8f03-88a8-485a-a777-dd3602f6c13e   col23946   cnx.org               mixins/                   carnival"
   "pl-u-physics-vol2          pl-u-physics                       16ab5b96-4598-45f9-993c-b8d78d82b0c6   col25244   cnx.org               mixins/                   carnival"

--- a/styles/books/pl-economics/book.scss
+++ b/styles/books/pl-economics/book.scss
@@ -1,0 +1,180 @@
+$PagesWithBands: (
+  (pageName: eoc, firstSelector: '.os-eoc.os-glossary-container', generalSelector: '.os-eoc'),
+  (pageName: eob, firstSelector: '.os-eob[data-type="composite-chapter"]', generalSelector: '.os-eob'),
+);
+
+$bandColor: #DCB83D;
+
+@import 'framework/framework';
+@import '../../design-settings/cosmos/_design.scss';
+@import '../../design-settings/cosmos/_settings.scss';
+@import '../../designs/cosmos/pdf/locale/pl/folio';
+
+
+// Settings
+// Iconned Notes
+@include add_settings((
+  BringItHome: (
+    _selectors: ('.economics.bringhome'),
+    'Container:::box-decoration-break': slice,
+    'Title:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'Title:::font-family': (_ref: 'typography:::titleOption3Font'),
+    'Title:::border-color': (_ref: 'colorMap:::iconnedNoteBorderColorBrown'),
+    'TitleIcon:::background': url(toDataUri("svg+xml", "designs/cosmos/resources/cosmos-home.svg")) no-repeat bottom left,
+    'TitleIcon:::height': v-spacing(4),
+    'TitleIcon:::width': v-spacing(4),
+    'TitleIcon:::bottom': -0.7rem,
+    'Body:::font-family': (_ref: 'typography:::titleOption2Font'),
+    'Body:::border-color': (_ref: 'colorMap:::iconnedNoteBorderColorBrown'),
+    'Subtitle:::color': (_ref: 'colorMap:::fontBodyColor'),
+    'Subtitle:::font-family': (_ref: 'typography:::titleOption1Font'),
+  ),
+));
+
+// Condensed icon note
+@include add_settings((
+  LinkItUp:(
+      _selectors: (".economics.linkup"),
+      'Container:::box-decoration-break': slice,
+      'Body:::border-bottom-color': (_ref: 'colorMap:::linkToLearningBottomBorderColor'),
+      'Title:::font-family': (_ref: 'typography:::titleOption3Font'),
+      'Icon:::background': url(toDataUri("svg+xml", "designs/cosmos/resources/carnival-linktolearning.svg")) no-repeat top left,
+    ),
+  ClearItUp: (
+        _selectors: ('.economics.clearup'),
+        'Container:::box-decoration-break': slice,
+        'Title:::color': (_ref: 'colorMap:::fontBodyColor'),
+        'Title:::font-family': (_ref: 'typography:::titleOption3Font'),
+        'Title:::border-color': (_ref: 'colorMap:::iconnedNoteBorderColorBlue2'),
+        'TitleIcon:::background': url(toDataUri("svg+xml", "designs/cosmos/resources/cosmos-coin.svg")) no-repeat bottom left,
+        'TitleIcon:::height': v-spacing(4),
+        'TitleIcon:::width': v-spacing(4),
+        'TitleIcon:::bottom': -0.7rem,
+        'Body:::font-family': (_ref: 'typography:::titleOption2Font'),
+        'Body:::border-color': (_ref: 'colorMap:::iconnedNoteBorderColorBlue2'),
+        'Subtitle:::color': (_ref: 'colorMap:::fontBodyColor'),
+        'Subtitle:::font-family': (_ref: 'typography:::titleOption1Font'),
+    ),
+));
+
+// Boxed Notes
+@include add_settings((
+    WorkItOut: (
+      _selectors: ('.economics.workout'),
+      'Title:::color': (_ref: 'colorMap:::boxedNoteTitleColor'),
+      'Title:::font-family': (_ref: 'typography:::titleOption3Font'),
+      'Title:::background-color': (_ref: 'colorMap:::boxedNoteTitleBackgroundOption1Color'),
+      'Title:::border-color': (_ref: 'colorMap:::boxedNoteTitleBorderColor'),
+      'Body:::font-family': (_ref: 'typography:::titleOption2Font'),
+      'Body:::background-color': (_ref: 'colorMap:::boxedNoteBodyBackgroundOption1Color'),
+      'Subtitle:::color': (_ref: 'colorMap:::fontBodyColor'),
+      'Subtitle:::font-family': (_ref: 'typography:::titleOption1Font'),
+    ),
+));
+
+// EOC exercises
+@include add_settings((
+  SelfCheckQuestions: (
+    _selectors: ('.os-eoc.os-self-check-questions-container'),
+    'ProblemNumber:::color': (_ref: "colorMap:::fontBodyColor"),
+  ),
+  ReviewQuestions: (
+    _selectors: ('.os-eoc.os-review-questions-container'),
+    'ProblemNumber:::color': (_ref: "colorMap:::fontBodyColor"),
+  ),
+  CriticalThinking: (
+    _selectors: ('.os-eoc.os-critical-thinking-container'),
+    'ProblemNumber:::color': (_ref: "colorMap:::fontBodyColor"),
+  ),
+  Problems: (
+    _selectors: ('.os-eoc.os-problems-container'),
+    'ProblemNumber:::color': (_ref: "colorMap:::fontBodyColor"),
+  ),
+));
+
+
+
+@include add_settings((
+  TocNoUnit:(
+    _selectors: ('nav#toc'),
+    'NoUnitChapterLinkPage:::content': "leader('.') target-counter(attr(href), page)",
+    'NoUnitChapterLinkPage:::display': inline,
+    'NoUnitChapterLinkPage:::margin-left': 0,
+    'ChapterLinkPage:::content': "leader('.') target-counter(attr(href), page)",
+    'ChapterLinkPage:::display': inline,
+    'ChapterLinkPage:::margin-left': 0,
+    'ModuleLinkPage:::content': "leader('.') target-counter(attr(href), page)",
+    'ModuleLinkPage:::display': inline,
+    'ModuleLinkPage:::margin-left': 0,
+  ),
+));
+
+@include add_settings((
+    IndexName: (
+        _selectors: (".os-index-name-container"),
+        'GroupLabel:::font-family': (_ref: 'typography:::titleOption1Font'),
+        'PageNumber:::content': target-counter(attr(href, url), page),
+    ),
+    IndexTerm: (
+        _selectors: (".os-index-term-container"),
+        'GroupLabel:::font-family': (_ref: 'typography:::titleOption1Font'),
+        'PageNumber:::content': target-counter(attr(href, url), page),
+    ),
+    IndexForeign: (
+        _selectors: (".os-index-foreign-container"),
+        'GroupLabel:::font-family': (_ref: 'typography:::titleOption1Font'),
+        'PageNumber:::content': target-counter(attr(href, url), page),
+    ),
+));
+
+
+@include use('BookRoot', "common:::BookRoot");
+@include use('LearningObjectivesAbstractModule', 'cosmos:::LearningObjectivesModuleShape');
+@include use('ChapterIntroWithChapterObjectives', 'cosmos:::ChapterIntroWithChapterObjectivesShape');
+@include use('Link', 'cosmos:::LinkShape');
+@include use('Footnote', 'common:::FootnoteShape');
+@include use('FootnoteCall', 'common:::FootnoteCallShape');
+@include use('Figure', 'cosmos:::FigureShape');
+@include use('TocNoUnit', 'cosmos:::TocNoUnitShape');
+@include use('Equation', 'cosmos:::EquationShape');
+@include use('Blockquote', "cosmos:::BlockquoteShape");
+
+// Notes
+@include use('BringItHome', 'cosmos:::IconnedNoteWithSubtitleShape');
+@include use('LinkItUp', 'cosmos:::CondensedIconNoteShape');
+@include use('ClearItUp', 'cosmos:::IconnedNoteWithSubtitleShape');
+@include use('WorkItOut', 'cosmos:::BoxedNoteWithSubtitleShape');
+
+// Titles
+@include use('PageTitles', 'cosmos:::PageTitlesShape');
+@include use('ChapterTitles', 'cosmos:::ChapterTitlesShape');
+@include use('IntroductionPageTitles', 'cosmos:::IntroductionPageTitlesShape');
+@include use('EocCompositePageTitles', 'cosmos:::EocCompositePageTitlesShape');
+@include use('EobTitles', 'cosmos:::EobTitlesShape');
+
+//Tables
+@include use('DefaultTable', 'cosmos:::BasicTableShape');
+@include use('TopCaptionedTable', 'cosmos:::BasicTableShape');
+
+
+// Lists
+@include use('PageLists', 'cosmos:::PageListsShape');
+@include use('NotesLists', 'cosmos:::NotesListsShape');
+@include use('ExercisesProblemLists', 'cosmos:::ExercisesListsShape');
+@include use('ExercisesSolutionLists', 'cosmos:::ExercisesListsShape');
+
+// Eoc
+@include use('KeyTerms', 'cosmos:::KeyTermsShape');
+
+//Exercises
+@include use('SelfCheckQuestions', 'cosmos:::ExercisesModuleShape');
+@include use('ReviewQuestions', 'cosmos:::ExercisesModuleShape');
+@include use('CriticalThinking', 'cosmos:::ExercisesModuleShape');
+@include use('Problems', 'cosmos:::ExercisesModuleShape');
+
+// Eob
+@include use('EobReferencesWithoutNumbering', 'cosmos:::EobReferencesWithoutNumberingShape');
+@include use('AnswerKey', 'cosmos:::AnswerKeyShape');
+@include use('IndexName', 'cosmos:::IndexShape');
+@include use('IndexTerm', 'cosmos:::IndexShape');
+@include use('IndexForeign', 'cosmos:::IndexShape');

--- a/styles/output/pl-economics-pdf.css
+++ b/styles/output/pl-economics-pdf.css
@@ -1,0 +1,2287 @@
+@charset "UTF-8";
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:wght@400;700&display=swap&subset=latin,latin-ext");
+@import url("https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;700&display=swap&subset=latin,latin-ext");
+@import url("https://fonts.googleapis.com/css2?family=Archivo:wght@400;500;600;700&display=swap&subset=latin,latin-ext");
+@import url("https://fonts.googleapis.com/css2?family=Archivo+Black&display=swap&subset=latin,latin-ext");
+@import url("https://fonts.googleapis.com/css2?family=Courier+Prime&display=swap");
+nav#toc > ol > .os-toc-unit > a > .os-text,
+nav#toc > ol > .os-toc-unit > a,
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > a > .os-number,
+nav#toc > ol > .os-toc-chapter > a > .os-number {
+  page-break-after: avoid; }
+
+nav#toc {
+  page-break-after: always; }
+
+nav#toc > ol > .os-toc-unit > ol > .os-toc-chapter > ol.os-chapter,
+nav#toc > ol > .os-toc-chapter > ol.os-chapter {
+  page-break-before: avoid; }
+
+h1, h2, h3, h4, h5, h6,
+[data-type="document-title"],
+[data-type="title"] {
+  break-after: avoid;
+  break-inside: avoid; }
+
+.learning-objectives,
+.learning-objective,
+[data-type="page"]:not(.introduction) > [data-type="abstract"] {
+  page-break-inside: avoid;
+  page-break-before: avoid; }
+
+[data-type="chapter"] .os-table,
+.os-table {
+  page-break-inside: auto; }
+  [data-type="chapter"] .os-table thead,
+  .os-table thead {
+    page-break-after: avoid; }
+  [data-type="chapter"] .os-table tr,
+  .os-table tr {
+    page-break-inside: avoid; }
+
+.os-table.os-top-titled-container > .os-table-title {
+  page-break-after: avoid; }
+
+.os-table.os-top-captioned-container > .os-top-caption {
+  page-break-after: avoid; }
+
+.footnote {
+  page-break-inside: avoid; }
+
+[data-type="footnote-refs"]::before {
+  page-break-after: avoid; }
+
+p.has-noteref {
+  page-break-inside: avoid; }
+
+.os-index-container {
+  page-break-before: right;
+  page-break-after: left; }
+  .os-index-container .group-label {
+    page-break-after: avoid; }
+  .os-index-container .group-by > .os-index-item:first-of-type {
+    break-before: avoid; }
+  .os-index-container .index-term, .os-index-container .os-term {
+    page-break-inside: avoid; }
+  .os-index-container .os-term-section-link {
+    page-break-after: avoid; }
+
+.os-eoc > section > [data-type="exercise"] {
+  page-break-inside: avoid; }
+
+.os-eos > section.section-exercises > section > [data-type="exercise"] {
+  page-break-inside: avoid; }
+
+div.preface,
+div[data-type="chapter"],
+div.appendix,
+div.os-solution-container[data-type="composite-chapter"],
+div.os-solutions-container[data-type="composite-chapter"],
+div.os-eob.os-references-container[data-type="composite-page"],
+div.os-eob.os-reference-container[data-type="composite-page"],
+div.handbook {
+  page-break-before: right;
+  page-break-after: left; }
+
+.os-caption-container {
+  page-break-before: avoid; }
+
+[data-type="equation"] {
+  page-break-inside: avoid; }
+
+.introduction > .intro-body > .os-chapter-outline > div.os-chapter-objective > a.os-chapter-objective {
+  page-break-after: avoid; }
+  .introduction > .intro-body > .os-chapter-outline > div.os-chapter-objective > a.os-chapter-objective > .os-number,
+  .introduction > .intro-body > .os-chapter-outline > div.os-chapter-objective > a.os-chapter-objective > .os-text {
+    page-break-after: avoid; }
+
+.os-chapter-outline > div.os-chapter-objective > div.learning-objective {
+  page-break-inside: auto; }
+
+/* stylelint-disable-next-line meowtec/no-px */
+* {
+  box-sizing: border-box; }
+
+[data-type="composite-chapter"] p, [data-type="composite-chapter"] section, [data-type="composite-chapter"] table, [data-type="composite-chapter"] ul, [data-type="composite-chapter"] ol, [data-type="composite-chapter"] li, [data-type="composite-chapter"] dl, [data-type="composite-chapter"] h1, [data-type="composite-chapter"] h2, [data-type="composite-chapter"] h3, [data-type="composite-chapter"] h4, [data-type="composite-chapter"] h5,
+[data-type="page"] p,
+[data-type="page"] section,
+[data-type="page"] table,
+[data-type="page"] ul,
+[data-type="page"] ol,
+[data-type="page"] li,
+[data-type="page"] dl,
+[data-type="page"] h1,
+[data-type="page"] h2,
+[data-type="page"] h3,
+[data-type="page"] h4,
+[data-type="page"] h5,
+[data-type="composite-page"] p,
+[data-type="composite-page"] section,
+[data-type="composite-page"] table,
+[data-type="composite-page"] ul,
+[data-type="composite-page"] ol,
+[data-type="composite-page"] li,
+[data-type="composite-page"] dl,
+[data-type="composite-page"] h1,
+[data-type="composite-page"] h2,
+[data-type="composite-page"] h3,
+[data-type="composite-page"] h4,
+[data-type="composite-page"] h5 {
+  margin: 0;
+  padding: 0; }
+
+[data-type="composite-chapter"] p,
+[data-type="page"] p,
+[data-type="composite-page"] p {
+  margin-bottom: 0.7rem; }
+
+[data-type="composite-chapter"] section,
+[data-type="page"] section,
+[data-type="composite-page"] section {
+  margin-bottom: 0.7rem; }
+
+[data-type="composite-chapter"] table,
+[data-type="page"] table,
+[data-type="composite-page"] table {
+  margin-bottom: 0.7rem; }
+
+[data-type="composite-chapter"] ul,
+[data-type="page"] ul,
+[data-type="composite-page"] ul {
+  margin-bottom: 0.7rem; }
+
+[data-type="composite-chapter"] ol,
+[data-type="page"] ol,
+[data-type="composite-page"] ol {
+  margin-bottom: 0.7rem; }
+
+math {
+  vertical-align: middle; }
+
+sub, sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline; }
+
+sup {
+  top: -0.5em; }
+
+sub {
+  bottom: -0.25em; }
+
+blockquote {
+  margin-top: 0;
+  margin-right: 0;
+  margin-bottom: 0;
+  margin-left: 0; }
+
+/* stylelint-disable-next-line meowtec/no-px */
+a[href^="http"]::after {
+  content: " (" attr(href) ")";
+  overflow-wrap: break-word; }
+
+ol.os-stepwise {
+  list-style-type: none; }
+
+ul[data-labeled-item="true"] {
+  list-style-type: none; }
+
+.os-math-in-para {
+  white-space: nowrap; }
+
+span[data-type="term"]:not(.no-emphasis) {
+  font-weight: bold; }
+
+h3, h4, h5 {
+  bookmark-level: none; }
+
+p.has-noteref {
+  margin-bottom: -0.7rem; }
+
+pre > span {
+  white-space: normal;
+  vertical-align: top;
+  display: inline-block; }
+
+iframe {
+  display: none; }
+
+.os-eoc.os-glossary-container {
+  page: eoc;
+  prince-page-group: start; }
+
+.os-eoc {
+  page: eoc; }
+
+.os-eob[data-type="composite-chapter"] {
+  page: eob;
+  prince-page-group: start; }
+
+.os-eob {
+  page: eob; }
+
+@page eoc:left {
+  @left-middle {
+    content: " ";
+    border-left: 0.65in solid #DCB83D;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @top-left-corner {
+    content: " ";
+    border-left: 0.65in solid #DCB83D;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @bottom-left-corner {
+    content: " ";
+    border-left: 0.65in solid #DCB83D;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @left-bottom {
+    content: " ";
+    border-left: 0.65in solid #DCB83D;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @left-top {
+    content: " ";
+    border-left: 0.65in solid #DCB83D;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; } }
+
+@page eoc:right {
+  @right-middle {
+    content: " ";
+    border-right: 0.65in solid #DCB83D;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @top-right-corner {
+    content: " ";
+    border-right: 0.65in solid #DCB83D;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @bottom-right-corner {
+    content: " ";
+    border-right: 0.65in solid #DCB83D;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @right-bottom {
+    content: " ";
+    border-right: 0.65in solid #DCB83D;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @right-top {
+    content: " ";
+    border-right: 0.65in solid #DCB83D;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; } }
+
+@page eoc:blank {
+  @left-middle {
+    content: none;
+    border: none; }
+  @top-left-corner {
+    content: none;
+    border: none; }
+  @bottom-left-corner {
+    content: none;
+    border: none; }
+  @left-bottom {
+    content: none;
+    border: none; }
+  @left-top {
+    content: none;
+    border: none; } }
+
+@page eoc:blank {
+  @right-middle {
+    content: none;
+    border: none; }
+  @top-right-corner {
+    content: none;
+    border: none; }
+  @bottom-right-corner {
+    content: none;
+    border: none; }
+  @right-bottom {
+    content: none;
+    border: none; }
+  @right-top {
+    content: none;
+    border: none; } }
+
+@page eob:left {
+  @left-middle {
+    content: " ";
+    border-left: 0.65in solid #DCB83D;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @top-left-corner {
+    content: " ";
+    border-left: 0.65in solid #DCB83D;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @bottom-left-corner {
+    content: " ";
+    border-left: 0.65in solid #DCB83D;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @left-bottom {
+    content: " ";
+    border-left: 0.65in solid #DCB83D;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; }
+  @left-top {
+    content: " ";
+    border-left: 0.65in solid #DCB83D;
+    padding: 2.4rem 0 2.4rem 2.4rem;
+    margin: -1.2rem 0 -1.2rem -1.2rem; } }
+
+@page eob:right {
+  @right-middle {
+    content: " ";
+    border-right: 0.65in solid #DCB83D;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @top-right-corner {
+    content: " ";
+    border-right: 0.65in solid #DCB83D;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @bottom-right-corner {
+    content: " ";
+    border-right: 0.65in solid #DCB83D;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @right-bottom {
+    content: " ";
+    border-right: 0.65in solid #DCB83D;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; }
+  @right-top {
+    content: " ";
+    border-right: 0.65in solid #DCB83D;
+    padding: 2.4rem 2.4rem 2.4rem 0;
+    margin: -1.2rem -1.2rem -1.2rem 0; } }
+
+@page eob:blank {
+  @left-middle {
+    content: none;
+    border: none; }
+  @top-left-corner {
+    content: none;
+    border: none; }
+  @bottom-left-corner {
+    content: none;
+    border: none; }
+  @left-bottom {
+    content: none;
+    border: none; }
+  @left-top {
+    content: none;
+    border: none; } }
+
+@page eob:blank {
+  @right-middle {
+    content: none;
+    border: none; }
+  @top-right-corner {
+    content: none;
+    border: none; }
+  @bottom-right-corner {
+    content: none;
+    border: none; }
+  @right-bottom {
+    content: none;
+    border: none; }
+  @right-top {
+    content: none;
+    border: none; } }
+
+@page {
+  @footnotes {
+    border-top-color: #000000;
+    border-top-width: 0.5pt;
+    border-top-style: solid;
+    display: block;
+    margin-top: 0.7rem; } }
+
+/* stylelint-disable-next-line meowtec/no-px */
+[data-type="chapter"] > h1[data-type="document-title"] .os-number {
+  string-set: chapter-number content(); }
+
+[data-type="chapter"] > h1[data-type="document-title"] .os-text {
+  string-set: chapter-title content(); }
+
+[data-type="chapter"] > [data-type="page"].introduction .intro-text > h2[data-type="document-title"] {
+  string-set: module-number string(chapter-number); }
+  [data-type="chapter"] > [data-type="page"].introduction .intro-text > h2[data-type="document-title"] .os-text {
+    string-set: module-title "Introduction"; }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > h2[data-type="document-title"] .os-number {
+  string-set: module-number content(); }
+
+[data-type="chapter"] > [data-type="page"]:not(.introduction) > h2[data-type="document-title"] .os-text {
+  string-set: module-title content(); }
+
+.os-eoc > h2[data-type="document-title"] .os-text {
+  string-set: eoc-title content(); }
+
+.appendix > h1[data-type="document-title"] .os-number {
+  string-set: appendix-number content(); }
+
+.appendix > h1[data-type="document-title"] .os-text {
+  string-set: appendix-title content(); }
+
+div[data-type="composite-page"].os-eob > h1[data-type="document-title"] .os-text {
+  string-set: eob-title content(); }
+
+nav#toc {
+  page: table-of-contents; }
+
+div[data-type="page"].preface {
+  page: preface;
+  counter-reset: page 1; }
+
+.os-eoc {
+  page: eoc; }
+
+[data-type="chapter"] {
+  page: chapter;
+  prince-page-group: start; }
+
+div[data-type="page"].appendix {
+  page: appendix; }
+
+div[data-type="composite-page"].os-eob {
+  page: eob; }
+
+@page chapter:nth(1) {
+  @top-left-corner {
+    content: none; }
+  @top-right-corner {
+    content: none; }
+  @top-left {
+    content: none; }
+  @top-center {
+    content: none; }
+  @top-right {
+    content: none; } }
+
+@page table-of-contents {
+  @top-left-corner {
+    content: none; }
+  @top-left {
+    content: none; }
+  @top-right-corner {
+    content: none; }
+  @top-right {
+    content: none; } }
+
+@page :left {
+  @top-left {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: string(chapter-number) " • " string(chapter-title); }
+  @top-left-corner {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: counter(page) "     "; }
+  @bottom-left {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: "Podręcznik dostępny na openstax.org"; } }
+
+@page :right {
+  @top-right {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: string(module-number) " • " string(module-title); }
+  @top-right-corner {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: "     " counter(page); } }
+
+@page preface:left {
+  @top-left {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: "Przedmowa"; }
+  @top-left-corner {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: counter(page) "     "; }
+  @bottom-left {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: "Podręcznik dostępny na openstax.org"; } }
+
+@page preface:right {
+  @top-right {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: "Przedmowa"; }
+  @top-right-corner {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: "     " counter(page); } }
+
+@page eoc:left {
+  @top-left {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: counter(page) "     " string(chapter-number) " • " string(eoc-title); }
+  @bottom-left {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: "Podręcznik dostępny na openstax.org"; } }
+
+@page eoc:right {
+  @top-right {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: string(chapter-number) " • " string(eoc-title) "     " counter(page); } }
+
+@page appendix:left {
+  @top-left {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: counter(page) "     " string(appendix-number) " • " string(appendix-title); }
+  @bottom-left {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: "Podręcznik dostępny na openstax.org"; } }
+
+@page appendix:right {
+  @top-right {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: string(appendix-number) " • " string(appendix-title) "     " counter(page); } }
+
+@page eob:left {
+  @top-left {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: counter(page) "     " string(eob-title); }
+  @bottom-left {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: "Podręcznik dostępny na openstax.org"; } }
+
+@page eob:right {
+  @top-right {
+    font-size: 0.83333rem;
+    font-family: "IBM Plex Sans";
+    color: #000000;
+    font-weight: 700;
+    content: string(eob-title) "     " counter(page); } }
+
+@page {
+  margin-left: 1in;
+  margin-right: 1in;
+  margin-bottom: 0.8in;
+  margin-top: 0.8in; }
+
+:root {
+  font-family: IBM Plex Serif, serif, StixGeneral;
+  font-size: 12px;
+  line-height: 1.5rem;
+  color: #000000;
+  prince-image-resolution: auto, 200dpi;
+  prince-background-image-resolution: 200dpi; }
+
+[data-type="page"] [data-type="abstract"] > h3[data-type="title"] {
+  color: #8B693A;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  margin-bottom: 0; }
+
+[data-type="page"] [data-type="abstract"] > p {
+  margin: 0;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral; }
+
+[data-type="page"] [data-type="abstract"] > ul {
+  margin-left: 24px;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral; }
+
+.introduction > .os-figure.has-splash {
+  background-color: #000000;
+  width: 8.8in;
+  position: relative;
+  z-index: -1;
+  box-sizing: border-box;
+  top: 0;
+  margin-bottom: 3.5rem;
+  padding-top: 3.5rem;
+  transform: translate3d(-1in, 0, 0);
+  margin-left: -1.2rem;
+  padding-bottom: 1.4rem;
+  margin-top: -0.1rem; }
+
+.introduction > .os-figure.has-splash > figure.splash {
+  margin-bottom: 1.4rem;
+  display: table;
+  margin-left: auto;
+  margin-right: auto; }
+
+.introduction > .os-figure.has-splash > figure.splash > span[data-type="media"] {
+  display: flex;
+  width: 6.5in;
+  line-height: 0;
+  justify-content: center; }
+
+.introduction > .os-figure.has-splash > .os-caption-container {
+  display: table;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 0.7rem;
+  width: 6.5in; }
+
+.introduction > .os-figure.has-splash > .os-caption-container > .os-number {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #DCB83D; }
+
+.introduction > .os-figure.has-splash > .os-caption-container > .os-title-label {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #DCB83D;
+  text-transform: uppercase; }
+
+.introduction > .os-figure.has-splash > .os-caption-container > .os-title {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-weight: 500;
+  font-size: 1rem;
+  color: #DCB83D; }
+
+.introduction > .os-figure.has-splash > .os-caption-container > .os-caption {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  font-weight: 400;
+  color: #FFFFFF; }
+
+.introduction > .intro-body > [data-type="note"].economics.chapter-objectives {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  margin-bottom: 2.1rem; }
+
+.introduction > .intro-body > [data-type="note"].economics.chapter-objectives > .os-title {
+  margin-bottom: 0.7rem;
+  font-family: Archivo, sans-serif, StixGeneral;
+  color: #8B693A;
+  font-weight: 700;
+  text-transform: uppercase; }
+
+.introduction > .intro-body > [data-type="note"].economics.chapter-objectives > .os-note-body > p {
+  margin-bottom: 0; }
+
+.introduction > .intro-body > [data-type="note"].economics.chapter-objectives > .os-note-body > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+.introduction > .intro-body > .intro-text > h2[data-type="document-title"]:first-of-type {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.728rem;
+  font-weight: 600;
+  color: #C31427;
+  margin-bottom: 0.7rem; }
+
+a {
+  color: #027EB5; }
+
+aside[role="doc-footnote"] {
+  float: footnote;
+  -prince-float-reference: page;
+  color: #000000;
+  line-height: 1.5rem;
+  font-family: IBM Plex Serif, serif, StixGeneral;
+  font-size: 0.83333rem;
+  text-align: left;
+  font-weight: normal; }
+
+aside[role="doc-footnote"]::footnote-call {
+  content: none; }
+
+aside[role="doc-footnote"]::footnote-marker {
+  content: none; }
+
+aside[role="doc-footnote"] [data-type="footnote-number"] {
+  display: inline-block;
+  margin-right: 8px; }
+
+a[role="doc-noteref"] {
+  font-family: IBM Plex Serif, serif, StixGeneral;
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+  top: -0.7em;
+  text-decoration: none;
+  padding-right: 0.16rem; }
+
+.os-figure:not(.has-splash) > figure {
+  display: table;
+  margin-left: auto;
+  margin-right: auto; }
+
+.os-figure:not(.has-splash) > .os-caption-container {
+  display: table;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 0.7rem; }
+
+.os-figure:not(.has-splash) > .os-caption-container > .os-title-label {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #8B1504;
+  text-transform: uppercase; }
+
+.os-figure:not(.has-splash) > .os-caption-container > .os-number {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #8B1504; }
+
+.os-figure:not(.has-splash) > .os-caption-container > .os-title {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-weight: 500;
+  font-size: 1rem;
+  color: #000000; }
+
+.os-figure:not(.has-splash) > .os-caption-container > .os-caption {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  font-weight: 400;
+  color: #000000; }
+
+nav#toc > .os-toc-title {
+  font-size: 2.98598rem;
+  line-height: 2.98598rem;
+  color: #C31427;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-weight: bold;
+  text-transform: uppercase;
+  padding-bottom: 2.1rem;
+  margin-bottom: 2.1rem;
+  border-bottom-style: solid;
+  border-bottom-color: #C31427;
+  border-bottom-width: 0.25rem; }
+
+nav#toc > ol {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0; }
+
+nav#toc > ol > li.os-toc-preface {
+  margin-bottom: 0.7rem; }
+
+nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-chapter) > a {
+  text-decoration: none; }
+
+nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-chapter) > a::after {
+  content: leader('.') target-counter(attr(href), page);
+  display: inline;
+  margin-left: 0;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  color: #000000;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-chapter) > a > .os-number {
+  font-family: Archivo, sans-serif, StixGeneral;
+  color: #000000;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-chapter) > a > .os-text {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  color: #000000;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+nav#toc > ol > li:not(.os-toc-unit):not(.os-toc-chapter) > ol {
+  display: none; }
+
+nav#toc > ol > li.os-toc-chapter {
+  margin-bottom: 0.7rem; }
+
+nav#toc > ol > li.os-toc-chapter > a {
+  text-decoration: none; }
+
+nav#toc > ol > li.os-toc-chapter > a > .os-number {
+  font-family: Archivo Black, sans-serif, StixGeneral;
+  color: #000000;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  text-transform: uppercase;
+  display: block; }
+
+nav#toc > ol > li.os-toc-chapter > a > .os-text {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  color: #C31427;
+  font-size: 1.728rem;
+  line-height: 1.5rem;
+  font-weight: 500; }
+
+nav#toc > ol > li.os-toc-chapter > a::after {
+  content: leader('.') target-counter(attr(href), page);
+  display: inline;
+  margin-left: 0;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  color: #000000;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: bold; }
+
+nav#toc > ol > li.os-toc-chapter > ol.os-chapter {
+  list-style: none;
+  margin-left: 0;
+  padding-left: 0; }
+
+nav#toc > ol > li.os-toc-chapter > ol.os-chapter > li > a {
+  text-decoration: none;
+  font-family: IBM Plex Serif, serif, StixGeneral;
+  color: #000000;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+nav#toc > ol > li.os-toc-chapter > ol.os-chapter > li > a::after {
+  content: leader('.') target-counter(attr(href), page);
+  display: inline;
+  margin-left: 0;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  color: #000000;
+  font-size: 1rem;
+  line-height: 1.5rem; }
+
+[data-type="equation"].unnumbered {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 0.7rem; }
+
+blockquote {
+  margin-left: 0.25in;
+  margin-right: 0.25in; }
+
+.economics.bringhome {
+  margin-bottom: 1.4rem;
+  box-decoration-break: slice; }
+
+.economics.bringhome > h3.os-title {
+  color: #000000;
+  font-family: Archivo Black, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  text-transform: uppercase;
+  font-weight: normal;
+  border-bottom: solid;
+  border-color: #8B693A;
+  position: relative; }
+
+.economics.bringhome > h3.os-title::before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI1LjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzMyAzMyIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzMgMzM7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRkZGRkZGO3N0cm9rZTojOEI2OTNBO3N0cm9rZS13aWR0aDoyLjI1O30KCS5zdDF7ZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7ZmlsbDojOEI2OTNBO30KPC9zdHlsZT4KPGcgaWQ9IkxheWVyXzFfMV8iPgoJPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMTYuNSIgY3k9IjE2LjUiIHI9IjE1LjQiLz4KPC9nPgo8Zz4KCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0yNSwyNC40aC01Ljd2LTUuN2gtNS43djUuN0g3Ljl2LTguNmMtMC44LDAtMS40LTAuNi0xLjQtMS40bDEwLTguNmw0LjMsMy43VjcuMmgyLjl2NC43bDIuOSwyLjUKCQljMCwwLjgtMC42LDEuNC0xLjQsMS40TDI1LDI0LjR6Ii8+CjwvZz4KPC9zdmc+Cg==) no-repeat bottom left;
+  background-size: contain;
+  height: 2.8rem;
+  width: 2.8rem;
+  content: '';
+  position: relative;
+  display: inline-block;
+  padding-right: 8px;
+  left: 0;
+  bottom: -0.7rem; }
+
+.economics.bringhome > .os-note-body {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  padding-top: 0.7rem;
+  padding-bottom: 0rem;
+  border-bottom: solid;
+  border-color: #8B693A;
+  box-decoration-break: slice; }
+
+.economics.bringhome > .os-note-body > h4.os-subtitle {
+  color: #000000;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-weight: normal;
+  margin-bottom: 0rem; }
+
+.economics.linkup {
+  margin-bottom: 1.4rem;
+  box-decoration-break: slice; }
+
+.economics.linkup > .os-note-body {
+  border-bottom-style: solid;
+  border-bottom-width: 0.125rem;
+  border-bottom-color: #78B042;
+  box-decoration-break: slice; }
+
+.economics.linkup > .os-note-body > p {
+  margin-bottom: 0.7rem; }
+
+.economics.linkup > .os-title {
+  margin-bottom: 0.7rem;
+  font-weight: 400;
+  letter-spacing: 0.05rem;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-family: Archivo Black, sans-serif, StixGeneral; }
+
+.economics.linkup > .os-title > .os-title-label {
+  display: inline-block;
+  word-wrap: normal;
+  text-transform: uppercase; }
+
+.economics.linkup > .os-title::before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDIzLjAuMywgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAyNyAyNyIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMjcgMjc7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRkZGRkZGO3N0cm9rZTojNzlCMTQyO3N0cm9rZS13aWR0aDoyLjI1O30KCS5zdDF7ZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7ZmlsbDojNzlCMTQyO30KPC9zdHlsZT4KPGcgaWQ9IlBhZ2UtMSI+Cgk8ZyBpZD0iSWNvbi1HdWlkZSIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTExNS4wMDAwMDAsIC0xOC4wMDAwMDApIj4KCQk8ZyBpZD0iR3JvdXAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKDExNi4wMDAwMDAsIDE5LjAwMDAwMCkiPgoJCQk8cGF0aCBpZD0iU3Ryb2tlLTMzIiBjbGFzcz0ic3QwIiBkPSJNMjQuMzMsMTIuMTJjMCw2LjYzLTUuMzcsMTItMTIsMTJzLTEyLTUuMzctMTItMTJzNS4zNy0xMiwxMi0xMgoJCQkJQzE4Ljk1LDAuMTIsMjQuMzMsNS41LDI0LjMzLDEyLjEyeiIvPgoJCQk8cGF0aCBpZD0iRmlsbC0xNSIgY2xhc3M9InN0MSIgZD0iTTEyLjEyLDUuMjJsLTIuMDYsMi4wOUM5LjksNy40OSw5LjczLDcuNjgsOS42LDcuODhDOS41Niw3LjkyLDkuNTQsNy45Nyw5LjUxLDguMDEKCQkJCWMwLjk5LTAuMjcsMi4wNS0wLjI2LDMuMDMsMC4wNWwwLjE3LTAuMTdsMS4xMy0xLjE1YzAuOTktMS4wMSwyLjYtMS4wMSwzLjU5LDBjMC45OSwxLjAxLDAuOTksMi42NCwwLDMuNjVsLTEuMjksMS4zMQoJCQkJbC0wLjI3LDAuMjdsLTAuMjYsMC4yNmwwLDBsLTAuNDMsMC40NGMtMC40NSwwLjQ1LTEuMDIsMC43LTEuNiwwLjc1bDAsMGwwLDBjLTAuMTIsMC4wMS0wLjIzLDAuMDEtMC4zMSwwLjAxCgkJCQljLTAuMDcsMC0wLjE3LTAuMDEtMC4xNy0wLjAxbC0wLjE1LTAuMDNsMCwwYy0wLjQ5LTAuMDktMC45Ny0wLjMzLTEuMzYtMC43MmMtMC4zNy0wLjM4LTAuNi0wLjg1LTAuNy0xLjMzCgkJCQljMC0wLjAxLDAtMC4wMy0wLjAxLTAuMDRjLTAuNDMsMC4wNC0wLjg2LDAuMjItMS4xOSwwLjU2bC0wLjY4LDAuNjljMC4yNCwwLjYsMC41OSwxLjE3LDEuMDcsMS42NnMxLjAzLDAuODUsMS42MywxLjA5CgkJCQljMC4xMSwwLjA0LDAuMjIsMC4wOCwwLjMzLDAuMTJjMC4wOSwwLjAzLDAuMTksMC4wNiwwLjI5LDAuMDhjMC4wMSwwLDAuMDEsMCwwLjAyLDBjMC4wMiwwLDAuMDMsMC4wMSwwLjA1LDAuMDEKCQkJCWMwLjk4LDAuMjMsMi4wMywwLjE0LDIuOTYtMC4yNmMwLjEyLTAuMDUsMC4yMy0wLjEsMC4zNC0wLjE2YzAuMDEsMCwwLjAxLTAuMDEsMC4wMi0wLjAxYzAuMDItMC4wMSwwLjA0LTAuMDIsMC4wNi0wLjAzCgkJCQljMC4wNS0wLjAzLDAuMS0wLjA1LDAuMTQtMC4wOGwwLDBjMC4zNC0wLjIxLDAuNjYtMC40NiwwLjk1LTAuNzVsMi4wNS0yLjA5YzEuODgtMS45MSwxLjg4LTUsMC02LjkKCQkJCUMxNy4wNCwzLjMyLDE0LDMuMzIsMTIuMTIsNS4yMiIvPgoJCQk8cGF0aCBpZD0iRmlsbC0xNyIgY2xhc3M9InN0MSIgZD0iTTEyLjI4LDE4Ljg2bDIuMDYtMi4wOWMwLjE4LTAuMTgsMC4zMy0wLjM3LDAuNDgtMC41N2MwLjAzLTAuMDQsMC4wNi0wLjA5LDAuMDktMC4xMwoJCQkJYy0wLjk5LDAuMjctMi4wNSwwLjI2LTMuMDMtMC4wNWwtMC4xNywwLjE4bC0xLjEzLDEuMTVjLTAuOTksMS4wMS0yLjYsMS4wMS0zLjU5LDBzLTAuOTktMi42NCwwLTMuNjVsMS4yOS0xLjMxbDAuMjctMC4yNwoJCQkJbDAuMjYtMC4yNmwwLDBsMC40My0wLjQ0YzAuNDUtMC40NiwxLjAyLTAuNywxLjYtMC43NWwwLDBsMCwwYzAuMTItMC4wMSwwLjIzLTAuMDEsMC4zMS0wLjAxYzAuMiwwLjAxLDAuMzEsMC4wNCwwLjMxLDAuMDRsMCwwCgkJCQlsMCwwYzAuNDksMC4wOSwwLjk3LDAuMzMsMS4zNSwwLjcyYzAuMzcsMC4zOCwwLjYsMC44NCwwLjcsMS4zM2MwLDAuMDEsMCwwLjAzLDAuMDEsMC4wNGMwLjQzLTAuMDQsMC44Ny0wLjIyLDEuMTktMC41NgoJCQkJbDAuNjgtMC43Yy0wLjI0LTAuNi0wLjU5LTEuMTctMS4wNy0xLjY2cy0xLjAzLTAuODUtMS42My0xLjA5Yy0wLjExLTAuMDQtMC4yMi0wLjA4LTAuMzMtMC4xMmMtMC4xLTAuMDMtMC4xOS0wLjA2LTAuMjktMC4wOAoJCQkJYy0wLjAxLDAtMC4wMSwwLTAuMDItMC4wMWMtMC4wMiwwLTAuMDMtMC4wMS0wLjA1LTAuMDFjLTAuOTgtMC4yMy0yLjAzLTAuMTQtMi45NiwwLjI2QzguOTUsOC44OSw4LjgzLDguOTQsOC43Miw5CgkJCQlDOC43MSw5LDguNzEsOS4wMSw4LjcsOS4wMUM4LjY4LDkuMDIsOC42Niw5LjAzLDguNjQsOS4wNEM4LjU5LDkuMDcsOC41NCw5LjA5LDguNSw5LjEybDAsMGMtMC4zNCwwLjItMC42NiwwLjQ1LTAuOTUsMC43NQoJCQkJbC0yLjA2LDIuMDljLTEuODgsMS45MS0xLjg4LDUsMCw2LjlDNy4zNywyMC43NywxMC40MSwyMC43NywxMi4yOCwxOC44NiIvPgoJCTwvZz4KCTwvZz4KPC9nPgo8L3N2Zz4K) no-repeat top left;
+  background-size: contain;
+  height: 1.4rem;
+  width: 1.4rem;
+  display: inline-block;
+  position: relative;
+  content: '';
+  padding-right: 8px; }
+
+.economics.clearup {
+  margin-bottom: 1.4rem;
+  box-decoration-break: slice; }
+
+.economics.clearup > h3.os-title {
+  color: #000000;
+  font-family: Archivo Black, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  text-transform: uppercase;
+  font-weight: normal;
+  border-bottom: solid;
+  border-color: #00819A;
+  position: relative; }
+
+.economics.clearup > h3.os-title::before {
+  background: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI1LjAuMSwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzMyAzMyIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzMgMzM7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRkZGRkZGO3N0cm9rZTojMDA4MTlBO3N0cm9rZS13aWR0aDoyLjI1O30KCS5zdDF7ZmlsbC1ydWxlOmV2ZW5vZGQ7Y2xpcC1ydWxlOmV2ZW5vZGQ7ZmlsbDojMDA4MTlBO30KPC9zdHlsZT4KPGcgaWQ9IkxheWVyXzFfMV8iPgoJPGNpcmNsZSBjbGFzcz0ic3QwIiBjeD0iMTYuNSIgY3k9IjE2LjUiIHI9IjE1LjQiLz4KPC9nPgo8Zz4KCTxnPgoJCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0xOC40LDE2LjZsLTAuOCwwLjNsMC43LDEuNWwwLjgtMC4zYzAuNC0wLjIsMC42LTAuNywwLjQtMS4xUzE4LjgsMTYuNCwxOC40LDE2LjYiLz4KCQk8cGF0aCBjbGFzcz0ic3QxIiBkPSJNMTQsMTQuOWMtMC40LDAuMi0wLjYsMC43LTAuNCwxLjFjMC4yLDAuNCwwLjcsMC42LDEuMSwwLjRsMC44LTAuM2wtMC43LTEuNUwxNCwxNC45eiIvPgoJCTxwYXRoIGNsYXNzPSJzdDEiIGQ9Ik0xOS43LDE5LjZMMTksMjBsMC4zLDAuOGMwLjIsMC40LDAsMC45LTAuNCwxLjFzLTAuOSwwLTEuMS0wLjRsLTAuMy0wLjhsLTEuNSwwLjdjLTAuNCwwLjItMC45LDAtMS4xLTAuNAoJCQljLTAuMi0wLjQsMC0wLjksMC40LTEuMWwxLjUtMC43bC0wLjctMS41bC0wLjgsMC4zYy0xLjMsMC42LTIuNywwLTMuMy0xLjNjLTAuNi0xLjMsMC0yLjcsMS4zLTMuM0wxNCwxM2wtMC4zLTAuOAoJCQljLTAuMi0wLjQsMC0wLjksMC40LTEuMWMwLjQtMC4yLDAuOSwwLDEuMSwwLjRsMC4zLDAuOGwxLjUtMC43YzAuNC0wLjIsMC45LDAsMS4xLDAuNGMwLjIsMC40LDAsMC45LTAuNCwxLjFsLTEuNSwwLjdsMC43LDEuNQoJCQlsMC44LTAuM2MxLjMtMC42LDIuNywwLDMuMywxLjNDMjEuNSwxNy42LDIxLDE5LjEsMTkuNywxOS42IE0xMi40LDcuNGMtNSwyLjItNy4zLDguMi01LjEsMTMuMnM4LjIsNy4zLDEzLjIsNS4xCgkJCXM3LjMtOC4yLDUuMS0xMy4yUzE3LjUsNS4xLDEyLjQsNy40Ii8+Cgk8L2c+CjwvZz4KPC9zdmc+Cg==) no-repeat bottom left;
+  background-size: contain;
+  height: 2.8rem;
+  width: 2.8rem;
+  content: '';
+  position: relative;
+  display: inline-block;
+  padding-right: 8px;
+  left: 0;
+  bottom: -0.7rem; }
+
+.economics.clearup > .os-note-body {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  padding-top: 0.7rem;
+  padding-bottom: 0rem;
+  border-bottom: solid;
+  border-color: #00819A;
+  box-decoration-break: slice; }
+
+.economics.clearup > .os-note-body > h4.os-subtitle {
+  color: #000000;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-weight: normal;
+  margin-bottom: 0rem; }
+
+.economics.workout {
+  margin-bottom: 1.4rem; }
+
+.economics.workout > .os-title {
+  color: #FFFFFF;
+  font-family: Archivo Black, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  text-transform: uppercase;
+  text-align: right;
+  font-weight: normal;
+  background-color: #38568A;
+  padding: 0.7rem;
+  position: relative;
+  border-bottom: solid;
+  border-color: #FFFFFF; }
+
+.economics.workout > .os-note-body {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  padding: 0.7rem;
+  background-color: #EFF3FA; }
+
+.economics.workout > .os-note-body > h4.os-subtitle {
+  color: #000000;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  font-weight: 500;
+  margin-bottom: 0rem; }
+
+.economics.workout > .os-note-body > ul.critical-thinking {
+  margin-left: 0;
+  padding-left: 24px;
+  padding-top: 0.7rem;
+  border-top-style: solid;
+  border-top-width: 0.1rem;
+  font-weight: 700; }
+
+[data-type="page"]:not(.introduction).preface > h1 {
+  color: #C31427;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.728rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+[data-type="page"]:not(.introduction) > h2 {
+  color: #C31427;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+[data-type="page"]:not(.introduction) > section > h2 {
+  color: #C31427;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+[data-type="page"]:not(.introduction) > section > h3 {
+  color: #C31427;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+[data-type="page"]:not(.introduction) > section > section > h3 {
+  color: #C31427;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+[data-type="page"]:not(.introduction) > section > section > h4 {
+  color: #C31427;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+[data-type="page"]:not(.introduction) > section > section > section > h5 {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 700; }
+
+[data-type="page"]:not(.introduction).appendix > h1 {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 2.98598rem;
+  line-height: 3rem;
+  font-weight: bold;
+  text-transform: uppercase;
+  margin-bottom: 0.7rem; }
+
+[data-type="page"]:not(.introduction).appendix > h1 > .os-text {
+  color: #C31427;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.728rem;
+  line-height: 1.5rem;
+  padding-top: 2.1rem;
+  margin-top: 2.1rem;
+  font-weight: 600;
+  text-transform: none;
+  border-top-color: #000000;
+  border-top-style: solid;
+  border-top-width: 0.1rem;
+  display: block; }
+
+[data-type="chapter"] {
+  height: 100%;
+  position: relative;
+  z-index: 1; }
+
+[data-type="chapter"] > h1 {
+  display: flex;
+  font-family: Archivo, sans-serif, StixGeneral;
+  position: relative;
+  font-weight: normal;
+  flex-direction: row;
+  justify-content: flex-start;
+  left: 0;
+  padding-top: 2.8rem;
+  margin-bottom: 0;
+  margin-top: -0.15in;
+  padding-bottom: 0; }
+
+[data-type="chapter"] > h1 > .os-part-text {
+  display: none; }
+
+[data-type="chapter"] > h1 > .os-number {
+  display: inline-block;
+  position: absolute;
+  color: #C31427;
+  font-weight: 700;
+  font-size: 4.29982rem;
+  line-height: 3rem;
+  right: 0;
+  top: 50%;
+  transform: translate(0, -50%); }
+
+[data-type="chapter"] > h1 > .os-text {
+  display: flex;
+  color: #FFFFFF;
+  font-size: 2.48832rem;
+  line-height: 3rem;
+  font-weight: 400;
+  max-width: 5in;
+  transform: translate(0, -50%);
+  left: 0;
+  top: 50%;
+  position: absolute;
+  padding-top: 0rem;
+  flex-wrap: wrap; }
+
+[data-type="chapter"] > h1::after {
+  content: '';
+  display: inline-block;
+  position: absolute;
+  bottom: 0;
+  background-color: #000000;
+  transform: translate3d(-1in, 0, 0);
+  left: 0;
+  z-index: -1;
+  width: 8.8in;
+  margin-left: -1.2rem;
+  height: 1.15in; }
+
+[data-type="page"].introduction > div > div > section > h3 {
+  color: #C31427;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+.os-eoc[data-type="composite-page"] > h2 {
+  color: #C31427;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+.os-eoc[data-type="composite-page"] > section > a > h3[data-type="document-title"] {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+.os-eoc[data-type="composite-page"] > div > div > section > a > h3[data-type="document-title"] {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.2rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+.os-eob > h1 {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 2.98598rem;
+  line-height: 3rem;
+  padding-bottom: 2.1rem;
+  margin-bottom: 2.1rem;
+  column-span: all;
+  font-weight: bold;
+  text-transform: uppercase;
+  border-bottom-color: #000000;
+  border-bottom-style: solid;
+  border-bottom-width: 0.1rem; }
+
+.os-eob > div > h2 {
+  color: #C31427;
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  margin-bottom: 0.7rem;
+  font-weight: 600; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) {
+  margin-bottom: 1.4rem;
+  display: table;
+  margin-left: auto;
+  margin-right: auto; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > .os-table-title {
+  color: #000000;
+  text-align: center;
+  font-weight: bold;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  padding: 0.7rem; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > .os-top-caption {
+  color: #000000;
+  text-align: center;
+  font-weight: bold;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  padding: 0.5rem; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 0; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table col[data-width='1*'] {
+  width: 25%; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > thead > tr:first-child > th:not(:only-child) {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-weight: bold;
+  font-size: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+  border-style: solid;
+  border-color: #000000;
+  border-width: 0.02rem;
+  border-left-style: none;
+  border-left-color: transparent;
+  border-left-width: 0rem;
+  border-right-style: none;
+  border-right-color: transparent;
+  border-right-width: 0rem; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > thead > tr:first-child > th:not(:only-child)[data-valign=top] {
+  vertical-align: top; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > thead > tr:first-child > th:not(:only-child)[data-align=left] {
+  text-align: left; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > thead > tr:first-child > th:not(:only-child)[data-align=right] {
+  text-align: right; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > thead > tr:first-child > th:not(:only-child)[data-align=center] {
+  text-align: center; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > thead > tr:not(:first-child):not(.header-row) > th:not(:only-child) {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-left-style: none;
+  border-left-color: transparent;
+  border-left-width: 0rem;
+  border-right-style: none;
+  border-right-color: transparent;
+  border-right-width: 0rem; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > thead > tr:not(:first-child):not(.header-row) > th:not(:only-child)[data-valign=top] {
+  vertical-align: top; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > thead > tr:not(:first-child):not(.header-row) > th:not(:only-child)[data-align=left] {
+  text-align: left; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > thead > tr:not(:first-child):not(.header-row) > th:not(:only-child)[data-align=right] {
+  text-align: right; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > thead > tr:not(:first-child):not(.header-row) > th:not(:only-child)[data-align=center] {
+  text-align: center; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr > td > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr > td > ul:not([data-labeled-item="true"]) > li > ul {
+  margin-left: 16px; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr > td > ol {
+  margin-left: 24px; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:not(:last-child):not(.header-row) > td:first-child:not(:only-child) {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-left-style: none;
+  border-left-color: transparent; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:not(:last-child):not(.header-row) > td:not(:first-child):not(:last-child):not(:only-child) {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-style: solid;
+  border-color: #000000;
+  border-width: 0.02rem; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:not(:last-child):not(.header-row) > td:last-child:not(:only-child) {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-right-style: none;
+  border-right-color: transparent; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:not(:last-child):not(.header-row) > td:only-child {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-right-style: none;
+  border-right-color: transparent;
+  border-left-style: none;
+  border-left-color: transparent; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:not(:last-child):not(.header-row)[data-valign=top] {
+  vertical-align: top; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:not(:last-child):not(.header-row) > td[data-align=left] {
+  text-align: left; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:not(:last-child):not(.header-row) > td[data-align=right] {
+  text-align: right; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:not(:last-child):not(.header-row) > td[data-align=center] {
+  text-align: center; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:last-child > td:first-child {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-left-style: none;
+  border-left-color: transparent; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:last-child > td:not(:first-child):not(:last-child) {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-style: solid;
+  border-color: #000000;
+  border-width: 0.02rem; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:last-child > td:last-child:not(:only-child) {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-right-style: none;
+  border-right-color: transparent; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:last-child > td:last-child:only-child {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-right-style: none;
+  border-left-style: none;
+  border-right-color: transparent;
+  border-left-color: transparent; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:last-child[data-valign=top] {
+  vertical-align: top; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:last-child > td[data-align=left] {
+  text-align: left; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:last-child > td[data-align=right] {
+  text-align: right; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr:last-child > td[data-align=center] {
+  text-align: center; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr.header-row > td {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-weight: bold;
+  font-size: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+  border-style: solid;
+  border-color: #000000;
+  border-width: 0.02rem;
+  border-left-style: none;
+  border-left-color: transparent;
+  border-left-width: 0rem;
+  border-right-style: none;
+  border-right-color: transparent;
+  border-right-width: 0rem; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr.header-row > td[data-valign=top] {
+  vertical-align: top; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr.header-row > td > td[data-align=left] {
+  text-align: left; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr.header-row > td > td[data-align=right] {
+  text-align: right; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > table > tbody > tr.header-row > td > td[data-align=center] {
+  text-align: center; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > .os-caption-container {
+  display: table-caption;
+  margin-bottom: 0.7rem;
+  caption-side: bottom;
+  prince-caption-page: all; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > .os-caption-container:before {
+  content: '';
+  width: 100%;
+  border-bottom-color: #8B1504;
+  border-bottom-width: 0.12rem;
+  border-bottom-style: solid;
+  display: block;
+  position: relative;
+  top: -0.1rem;
+  margin-bottom: 0.7rem; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > .os-caption-container > .os-title-label {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #8B1504;
+  text-transform: uppercase; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > .os-caption-container > .os-number {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #8B1504; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > .os-caption-container > .os-title {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-weight: 500;
+  font-size: 1rem;
+  color: #000000; }
+
+.os-table:not(.os-text-heavy-top-titled-container):not(.os-unstyled-container) > .os-caption-container > .os-caption {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  font-weight: 400;
+  color: #000000; }
+
+.os-table.os-top-captioned-container {
+  margin-bottom: 1.4rem;
+  display: table;
+  margin-left: auto;
+  margin-right: auto; }
+
+.os-table.os-top-captioned-container > .os-table-title {
+  color: #000000;
+  text-align: center;
+  font-weight: bold;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  padding: 0.7rem; }
+
+.os-table.os-top-captioned-container > .os-top-caption {
+  color: #000000;
+  text-align: center;
+  font-weight: bold;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  padding: 0.5rem; }
+
+.os-table.os-top-captioned-container > table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 0; }
+
+.os-table.os-top-captioned-container > table col[data-width='1*'] {
+  width: 25%; }
+
+.os-table.os-top-captioned-container > table > thead > tr:first-child > th:not(:only-child) {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-weight: bold;
+  font-size: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+  border-style: solid;
+  border-color: #000000;
+  border-width: 0.02rem;
+  border-left-style: none;
+  border-left-color: transparent;
+  border-left-width: 0rem;
+  border-right-style: none;
+  border-right-color: transparent;
+  border-right-width: 0rem; }
+
+.os-table.os-top-captioned-container > table > thead > tr:first-child > th:not(:only-child)[data-valign=top] {
+  vertical-align: top; }
+
+.os-table.os-top-captioned-container > table > thead > tr:first-child > th:not(:only-child)[data-align=left] {
+  text-align: left; }
+
+.os-table.os-top-captioned-container > table > thead > tr:first-child > th:not(:only-child)[data-align=right] {
+  text-align: right; }
+
+.os-table.os-top-captioned-container > table > thead > tr:first-child > th:not(:only-child)[data-align=center] {
+  text-align: center; }
+
+.os-table.os-top-captioned-container > table > thead > tr:not(:first-child):not(.header-row) > th:not(:only-child) {
+  color: #000000;
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-left-style: none;
+  border-left-color: transparent;
+  border-left-width: 0rem;
+  border-right-style: none;
+  border-right-color: transparent;
+  border-right-width: 0rem; }
+
+.os-table.os-top-captioned-container > table > thead > tr:not(:first-child):not(.header-row) > th:not(:only-child)[data-valign=top] {
+  vertical-align: top; }
+
+.os-table.os-top-captioned-container > table > thead > tr:not(:first-child):not(.header-row) > th:not(:only-child)[data-align=left] {
+  text-align: left; }
+
+.os-table.os-top-captioned-container > table > thead > tr:not(:first-child):not(.header-row) > th:not(:only-child)[data-align=right] {
+  text-align: right; }
+
+.os-table.os-top-captioned-container > table > thead > tr:not(:first-child):not(.header-row) > th:not(:only-child)[data-align=center] {
+  text-align: center; }
+
+.os-table.os-top-captioned-container > table > tbody > tr > td > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+.os-table.os-top-captioned-container > table > tbody > tr > td > ul:not([data-labeled-item="true"]) > li > ul {
+  margin-left: 16px; }
+
+.os-table.os-top-captioned-container > table > tbody > tr > td > ol {
+  margin-left: 24px; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:not(:last-child):not(.header-row) > td:first-child:not(:only-child) {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-left-style: none;
+  border-left-color: transparent; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:not(:last-child):not(.header-row) > td:not(:first-child):not(:last-child):not(:only-child) {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-style: solid;
+  border-color: #000000;
+  border-width: 0.02rem; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:not(:last-child):not(.header-row) > td:last-child:not(:only-child) {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-right-style: none;
+  border-right-color: transparent; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:not(:last-child):not(.header-row) > td:only-child {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-right-style: none;
+  border-right-color: transparent;
+  border-left-style: none;
+  border-left-color: transparent; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:not(:last-child):not(.header-row)[data-valign=top] {
+  vertical-align: top; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:not(:last-child):not(.header-row) > td[data-align=left] {
+  text-align: left; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:not(:last-child):not(.header-row) > td[data-align=right] {
+  text-align: right; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:not(:last-child):not(.header-row) > td[data-align=center] {
+  text-align: center; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:last-child > td:first-child {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-left-style: none;
+  border-left-color: transparent; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:last-child > td:not(:first-child):not(:last-child) {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-style: solid;
+  border-color: #000000;
+  border-width: 0.02rem; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:last-child > td:last-child:not(:only-child) {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-right-style: none;
+  border-right-color: transparent; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:last-child > td:last-child:only-child {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  color: #000000;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+  border-width: 0.02rem;
+  border-style: solid;
+  border-color: #000000;
+  border-right-style: none;
+  border-left-style: none;
+  border-right-color: transparent;
+  border-left-color: transparent; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:last-child[data-valign=top] {
+  vertical-align: top; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:last-child > td[data-align=left] {
+  text-align: left; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:last-child > td[data-align=right] {
+  text-align: right; }
+
+.os-table.os-top-captioned-container > table > tbody > tr:last-child > td[data-align=center] {
+  text-align: center; }
+
+.os-table.os-top-captioned-container > table > tbody > tr.header-row > td {
+  font-weight: bold;
+  font-size: 1rem;
+  padding-top: 0.5rem;
+  padding-bottom: 0.5rem;
+  padding-right: 0.5rem;
+  padding-left: 0.5rem;
+  border-style: solid;
+  border-width: 0.02rem;
+  border-left-style: none;
+  border-left-color: transparent;
+  border-left-width: 0rem;
+  border-right-style: none;
+  border-right-color: transparent;
+  border-right-width: 0rem; }
+
+.os-table.os-top-captioned-container > table > tbody > tr.header-row > td[data-valign=top] {
+  vertical-align: top; }
+
+.os-table.os-top-captioned-container > table > tbody > tr.header-row > td > td[data-align=left] {
+  text-align: left; }
+
+.os-table.os-top-captioned-container > table > tbody > tr.header-row > td > td[data-align=right] {
+  text-align: right; }
+
+.os-table.os-top-captioned-container > table > tbody > tr.header-row > td > td[data-align=center] {
+  text-align: center; }
+
+.os-table.os-top-captioned-container > .os-caption-container {
+  display: table-caption;
+  margin-bottom: 0.7rem;
+  caption-side: bottom;
+  prince-caption-page: all; }
+
+.os-table.os-top-captioned-container > .os-caption-container:before {
+  content: '';
+  width: 100%;
+  border-bottom-color: #501616;
+  border-bottom-width: 0.12rem;
+  border-bottom-style: solid;
+  display: block;
+  position: relative;
+  top: -0.1rem;
+  margin-bottom: 0.7rem; }
+
+.os-table.os-top-captioned-container > .os-caption-container > .os-title-label {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #501616;
+  text-transform: uppercase; }
+
+.os-table.os-top-captioned-container > .os-caption-container > .os-number {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-weight: 700;
+  font-size: 1rem;
+  color: #501616; }
+
+.os-table.os-top-captioned-container > .os-caption-container > .os-title {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-weight: 500;
+  font-size: 1rem;
+  color: #000000; }
+
+.os-table.os-top-captioned-container > .os-caption-container > .os-caption {
+  font-family: IBM Plex Sans, sans-serif, StixGeneral;
+  font-size: 1rem;
+  font-weight: 400;
+  color: #000000; }
+
+[data-type="page"] > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="page"] > ul:not([data-labeled-item="true"]) > li > ul {
+  margin-left: 16px; }
+
+[data-type="page"] > ul[data-bullet-style='none'] {
+  list-style-type: none; }
+
+[data-type="page"] > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > ol > li > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > section > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="page"] > section > ul:not([data-labeled-item="true"]) > li > ul {
+  margin-left: 16px; }
+
+[data-type="page"] > section > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > section > ol > li > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > section > section > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="page"] > section > section > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > div > div > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="page"] > div > div > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > div > div > section > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="page"] > div > div > section > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > section > section > section > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="page"] > section > section > section > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > section > section > section > ol > li > ul {
+  margin-left: 16px; }
+
+[data-type="page"] > section > section > section > section > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="page"] > section > section > section > section > ol {
+  margin-left: 24px; }
+
+[data-type="page"] > section > section > section > section > ol > li > ul {
+  margin-left: 16px; }
+
+[data-type="note"] > div > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="note"] > div > ol {
+  margin-left: 24px; }
+
+[data-type="problem"] > div > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="problem"] > div > ol {
+  margin-left: 24px; }
+
+[data-type="exercise-question"] > div > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="exercise-question"] > div > ol {
+  margin-left: 24px; }
+
+[data-type="solution"] > div > ul:not([data-labeled-item="true"]) {
+  margin-left: 24px; }
+
+[data-type="solution"] > div > ol {
+  margin-left: 24px; }
+
+.os-eoc.os-glossary-container {
+  margin-bottom: 1.4rem; }
+
+.os-eoc.os-glossary-container > dl {
+  text-indent: -24px;
+  padding-left: 24px; }
+
+.os-eoc.os-glossary-container > dl > dt {
+  display: inline;
+  font-weight: bold; }
+
+.os-eoc.os-glossary-container > dl > dd {
+  display: inline;
+  margin-left: 2px; }
+
+.os-eoc.os-self-check-questions-container {
+  margin-bottom: 1.4rem; }
+
+.os-eoc.os-self-check-questions-container [data-type="exercise"] {
+  margin-bottom: 0.7rem; }
+
+.os-eoc.os-self-check-questions-container [data-type="exercise"] [data-type='problem'] {
+  display: table; }
+
+.os-eoc.os-self-check-questions-container [data-type="exercise"] [data-type='problem'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+.os-eoc.os-self-check-questions-container [data-type="exercise"] [data-type='problem'] > .os-divider {
+  margin-right: 8px; }
+
+.os-eoc.os-self-check-questions-container [data-type="exercise"] [data-type='problem'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+.os-eoc.os-self-check-questions-container [data-type="exercise"] [data-type='problem'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+.os-eoc.os-self-check-questions-container [data-type="injected-exercise"] {
+  margin-bottom: 0.7rem; }
+
+.os-eoc.os-self-check-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] {
+  display: table; }
+
+.os-eoc.os-self-check-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+.os-eoc.os-self-check-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] > .os-divider {
+  margin-right: 8px; }
+
+.os-eoc.os-self-check-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+.os-eoc.os-self-check-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > div[data-type="exercise-context"] {
+  display: inline; }
+
+.os-eoc.os-self-check-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > span.os-divider {
+  display: inline; }
+
+.os-eoc.os-self-check-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+.os-eoc.os-review-questions-container {
+  margin-bottom: 1.4rem; }
+
+.os-eoc.os-review-questions-container [data-type="exercise"] {
+  margin-bottom: 0.7rem; }
+
+.os-eoc.os-review-questions-container [data-type="exercise"] [data-type='problem'] {
+  display: table; }
+
+.os-eoc.os-review-questions-container [data-type="exercise"] [data-type='problem'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+.os-eoc.os-review-questions-container [data-type="exercise"] [data-type='problem'] > .os-divider {
+  margin-right: 8px; }
+
+.os-eoc.os-review-questions-container [data-type="exercise"] [data-type='problem'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+.os-eoc.os-review-questions-container [data-type="exercise"] [data-type='problem'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+.os-eoc.os-review-questions-container [data-type="injected-exercise"] {
+  margin-bottom: 0.7rem; }
+
+.os-eoc.os-review-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] {
+  display: table; }
+
+.os-eoc.os-review-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+.os-eoc.os-review-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] > .os-divider {
+  margin-right: 8px; }
+
+.os-eoc.os-review-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+.os-eoc.os-review-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > div[data-type="exercise-context"] {
+  display: inline; }
+
+.os-eoc.os-review-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > span.os-divider {
+  display: inline; }
+
+.os-eoc.os-review-questions-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+.os-eoc.os-critical-thinking-container {
+  margin-bottom: 1.4rem; }
+
+.os-eoc.os-critical-thinking-container [data-type="exercise"] {
+  margin-bottom: 0.7rem; }
+
+.os-eoc.os-critical-thinking-container [data-type="exercise"] [data-type='problem'] {
+  display: table; }
+
+.os-eoc.os-critical-thinking-container [data-type="exercise"] [data-type='problem'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+.os-eoc.os-critical-thinking-container [data-type="exercise"] [data-type='problem'] > .os-divider {
+  margin-right: 8px; }
+
+.os-eoc.os-critical-thinking-container [data-type="exercise"] [data-type='problem'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+.os-eoc.os-critical-thinking-container [data-type="exercise"] [data-type='problem'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+.os-eoc.os-critical-thinking-container [data-type="injected-exercise"] {
+  margin-bottom: 0.7rem; }
+
+.os-eoc.os-critical-thinking-container [data-type="injected-exercise"] [data-type='exercise-question'] {
+  display: table; }
+
+.os-eoc.os-critical-thinking-container [data-type="injected-exercise"] [data-type='exercise-question'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+.os-eoc.os-critical-thinking-container [data-type="injected-exercise"] [data-type='exercise-question'] > .os-divider {
+  margin-right: 8px; }
+
+.os-eoc.os-critical-thinking-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+.os-eoc.os-critical-thinking-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > div[data-type="exercise-context"] {
+  display: inline; }
+
+.os-eoc.os-critical-thinking-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > span.os-divider {
+  display: inline; }
+
+.os-eoc.os-critical-thinking-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+.os-eoc.os-problems-container {
+  margin-bottom: 1.4rem; }
+
+.os-eoc.os-problems-container [data-type="exercise"] {
+  margin-bottom: 0.7rem; }
+
+.os-eoc.os-problems-container [data-type="exercise"] [data-type='problem'] {
+  display: table; }
+
+.os-eoc.os-problems-container [data-type="exercise"] [data-type='problem'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+.os-eoc.os-problems-container [data-type="exercise"] [data-type='problem'] > .os-divider {
+  margin-right: 8px; }
+
+.os-eoc.os-problems-container [data-type="exercise"] [data-type='problem'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+.os-eoc.os-problems-container [data-type="exercise"] [data-type='problem'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+.os-eoc.os-problems-container [data-type="injected-exercise"] {
+  margin-bottom: 0.7rem; }
+
+.os-eoc.os-problems-container [data-type="injected-exercise"] [data-type='exercise-question'] {
+  display: table; }
+
+.os-eoc.os-problems-container [data-type="injected-exercise"] [data-type='exercise-question'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+.os-eoc.os-problems-container [data-type="injected-exercise"] [data-type='exercise-question'] > .os-divider {
+  margin-right: 8px; }
+
+.os-eoc.os-problems-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container {
+  display: table-cell;
+  width: 100%; }
+
+.os-eoc.os-problems-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > div[data-type="exercise-context"] {
+  display: inline; }
+
+.os-eoc.os-problems-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > span.os-divider {
+  display: inline; }
+
+.os-eoc.os-problems-container [data-type="injected-exercise"] [data-type='exercise-question'] .os-problem-container > p {
+  margin-bottom: 0; }
+
+.os-eob.os-references-container > .os-chapter-area {
+  margin-bottom: 0.7rem; }
+
+.os-eob.os-references-container > .os-chapter-area > section > p {
+  text-indent: -16px;
+  padding-left: 16px; }
+
+.os-eob[data-type="composite-chapter"] > [data-type="composite-page"] {
+  margin-bottom: 1.4rem; }
+
+.os-eob[data-type="composite-chapter"] > [data-type="composite-page"] [data-type='solution'] {
+  display: table; }
+
+.os-eob[data-type="composite-chapter"] > [data-type="composite-page"] [data-type='solution'] > .os-number {
+  display: table-cell;
+  text-decoration: none;
+  color: #000000;
+  font-weight: bold; }
+
+.os-eob[data-type="composite-chapter"] > [data-type="composite-page"] [data-type='solution'] > .os-divider {
+  margin-right: 8px; }
+
+.os-eob[data-type="composite-chapter"] > [data-type="composite-page"] [data-type='solution'] .os-solution-container {
+  display: table-cell;
+  width: 100%; }
+
+.os-eob[data-type="composite-chapter"] > [data-type="composite-page"] [data-type='solution'] .os-solution-container > p {
+  margin-bottom: 0; }
+
+.os-eob[data-type="composite-chapter"] > [data-type="composite-page"] [data-type='solution'] .os-solution-container.has-first-element {
+  display: table-cell;
+  vertical-align: bottom;
+  padding-top: 0.7rem;
+  width: 100%; }
+
+.os-eob[data-type="composite-chapter"] > [data-type="composite-page"] [data-type='solution'] .os-solution-container.has-first-element > p {
+  margin-bottom: 0; }
+
+.os-index-name-container {
+  column-count: 3;
+  column-gap: 32px; }
+
+.os-index-name-container > .group-by {
+  margin-bottom: 1.4rem; }
+
+.os-index-name-container > .group-by > .group-label {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  font-weight: 600; }
+
+.os-index-name-container > .group-by > .os-index-item > .os-term {
+  padding-right: 8px; }
+
+.os-index-name-container > .group-by > .os-index-item > .os-term-section-link {
+  content: target-counter(attr(href, url), page); }
+
+.os-index-term-container {
+  column-count: 3;
+  column-gap: 32px; }
+
+.os-index-term-container > .group-by {
+  margin-bottom: 1.4rem; }
+
+.os-index-term-container > .group-by > .group-label {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  font-weight: 600; }
+
+.os-index-term-container > .group-by > .os-index-item > .os-term {
+  padding-right: 8px; }
+
+.os-index-term-container > .group-by > .os-index-item > .os-term-section-link {
+  content: target-counter(attr(href, url), page); }
+
+.os-index-foreign-container {
+  column-count: 3;
+  column-gap: 32px; }
+
+.os-index-foreign-container > .group-by {
+  margin-bottom: 1.4rem; }
+
+.os-index-foreign-container > .group-by > .group-label {
+  font-family: Archivo, sans-serif, StixGeneral;
+  font-size: 1.44rem;
+  line-height: 1.5rem;
+  font-weight: 600; }
+
+.os-index-foreign-container > .group-by > .os-index-item > .os-term {
+  padding-right: 8px; }
+
+.os-index-foreign-container > .group-by > .os-index-item > .os-term-section-link {
+  content: target-counter(attr(href, url), page); }
+
+/*# sourceMappingURL=pl-economics-pdf.css.map */


### PR DESCRIPTION
For: #4448
Within: https://github.com/openstax/cnx-recipes/issues/4300
In the book.scss file has been used almost the same styles as in the American economics (except for ToC, where the dots has been added and Indexes where there are three of them for polish books).