### PR TITLE
Mark kss-styleguide-builder for deletion

### DIFF
--- a/js/kss-styleguide-builder/index.js
+++ b/js/kss-styleguide-builder/index.js
@@ -1,3 +1,5 @@
+//delete_me
+
 const path = require('path')
 const KssBuilderBaseHandlebars = require('kss/builder/base/handlebars')
 


### PR DESCRIPTION
The folder kss-style-guide contains instructions on how to build a style guide for legacy baking, which is no longer supported as we've moved on to recipes/kitchen or cookbook