### PR TITLE
fix-splash-title

### DIFF
--- a/styles/books/pl-economics/book.scss
+++ b/styles/books/pl-economics/book.scss
@@ -177,7 +177,6 @@ $bandColor: #217867;
     'IntroContentHeaderEconomics:::color': (_ref: "colorMap:::introContentHeaderColorPlEconomics"),
     'SplashFigureWrapper:::background-color': (_ref: "colorMap:::chapterSplashFigureWrapperBgPlEconomicsColor"),
     'CaptionTitleLabel:::color': (_ref: "colorMap:::chapterIntroCaptionNumberPlEconomicsColor"),
-    'CaptionTitle:::color': (_ref: "colorMap:::chapterIntroCaptionNumberPlEconomicsColor"),
     'CaptionNumber:::color': (_ref: "colorMap:::chapterIntroCaptionNumberPlEconomicsColor"),
   ),
 ));

--- a/styles/design-settings/cosmos/parts/_chapterintro-settings.scss
+++ b/styles/design-settings/cosmos/parts/_chapterintro-settings.scss
@@ -121,7 +121,7 @@
         ),
         CaptionTitle:(
             font-family: (_ref: "typography:::titleOption1Font"),
-            color: (_ref: "colorMap:::chapterIntroCaptionNumberColor"),
+            color: (_ref: "colorMap:::chapterIntrocaptionTextColor"),
         ),
         CaptionNumber:(
             font-family: (_ref: "typography:::titleOption1Font"),

--- a/styles/design-settings/cosmos/parts/_chapterintro-settings.scss
+++ b/styles/design-settings/cosmos/parts/_chapterintro-settings.scss
@@ -119,7 +119,7 @@
             font-family: (_ref: "typography:::titleOption1Font"),
             color: (_ref: "colorMap:::chapterIntroCaptionNumberColor"),
         ),
-        CaptionTitle:(
+        CaptionTitleSplash:(
             font-family: (_ref: "typography:::titleOption1Font"),
             color: (_ref: "colorMap:::chapterIntrocaptionTextColor"),
         ),

--- a/styles/designs/cosmos/parts/_chapterintro-shapes.scss
+++ b/styles/designs/cosmos/parts/_chapterintro-shapes.scss
@@ -6,7 +6,7 @@
 @include create_shape('cosmos:::ChapterIntroWithLOShape', (
     _components: (
         map-merge($Introduction__Container, (
-            _components: (  
+            _components: (
             map-merge($ChapterSplash__Figure__Wrapper, (
                 _components: (
                     map-merge($ChapterSplash__Figure, (
@@ -25,7 +25,7 @@
                             $Caption__Text,
                         )
                     )),
-                    
+
                 )
             )),
             map-merge($ChapterIntro__Container, (
@@ -62,14 +62,14 @@
                 )),
             )
         )),
-    
+
     )
 ));
 
 @include create_shape('cosmos:::ChapterIntroShape', (
     _components: (
         map-merge($Introduction__Container, (
-            _components: (  
+            _components: (
             map-merge($ChapterSplash__Figure__Wrapper, (
                 _components: (
                     map-merge($ChapterSplash__Figure, (
@@ -89,7 +89,7 @@
                             $Caption__Text,
                         )
                     )),
-                    
+
                 )
             )),
             map-merge($ChapterIntro__Container, (
@@ -117,14 +117,14 @@
                 )),
             )
         )),
-    
+
     )
 ));
 
 @include create_shape('cosmos:::ChapterIntroWithChapterObjectivesShape', (
     _components: (
         map-merge($Introduction__Container, (
-            _components: (  
+            _components: (
             map-merge($ChapterSplash__Figure__Wrapper, (
                 _components: (
                     map-merge($ChapterSplash__Figure, (
@@ -140,11 +140,11 @@
                         _components: (
                             $Caption__Number,
                             $Caption__Title--Label,
-                            $Caption__Title,
+                            $Caption__Title--Splash,
                             $Caption__Text,
                         )
                     )),
-                    
+
                 )
             )),
             map-merge($ChapterIntro__Container, (
@@ -155,9 +155,9 @@
                             map-merge($ChapterObjectives__NoteBody, (
                                 _components: (
                                     $Chapter__Objectives--Paragraph,
-                                    $UnorderedList--FirstLevel, 
+                                    $UnorderedList--FirstLevel,
                                 )
-                            )),                           
+                            )),
                         )
                     )),
                     map-merge($ChapterIntro__Content, (

--- a/styles/output/economics-pdf.css
+++ b/styles/output/economics-pdf.css
@@ -848,7 +848,7 @@ div[data-type="page"].handbook {
   font-family: Archivo, sans-serif, StixGeneral;
   font-weight: 500;
   font-size: 1rem;
-  color: #DCB83D; }
+  color: #FFFFFF; }
 
 .introduction > .os-figure.has-splash > .os-caption-container > .os-caption {
   font-family: IBM Plex Sans, sans-serif, StixGeneral;

--- a/styles/output/economics-pdf.css
+++ b/styles/output/economics-pdf.css
@@ -846,7 +846,7 @@ div[data-type="page"].handbook {
 
 .introduction > .os-figure.has-splash > .os-caption-container > .os-title {
   font-family: Archivo, sans-serif, StixGeneral;
-  font-weight: 500;
+  font-weight: 700;
   font-size: 1rem;
   color: #FFFFFF; }
 

--- a/styles/output/pl-economics-pdf.css
+++ b/styles/output/pl-economics-pdf.css
@@ -690,7 +690,7 @@ div[data-type="composite-page"].os-eob {
 
 .introduction > .os-figure.has-splash > .os-caption-container > .os-title {
   font-family: Archivo, sans-serif, StixGeneral;
-  font-weight: 500;
+  font-weight: 700;
   font-size: 1rem;
   color: #FFFFFF; }
 

--- a/styles/output/pl-economics-pdf.css
+++ b/styles/output/pl-economics-pdf.css
@@ -692,7 +692,7 @@ div[data-type="composite-page"].os-eob {
   font-family: Archivo, sans-serif, StixGeneral;
   font-weight: 500;
   font-size: 1rem;
-  color: #8F007E; }
+  color: #FFFFFF; }
 
 .introduction > .os-figure.has-splash > .os-caption-container > .os-caption {
   font-family: IBM Plex Sans, sans-serif, StixGeneral;


### PR DESCRIPTION
Splash title should be white. There was a mistake in American and Polish economics.
Also wrong component was used in the shape.