### PR TITLE
Include webview-generic.css sourcemap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,8 @@ package-lock.json
 /recipes/books/styleguide/*-baked.xhtml
 /sassdoc/
 /styleguide/
-/styles/output/*.css.map
+/styles/output/*-pdf.css.map
+/styles/output/*-web.css.map
 
 # CSS coverage report (as a clickable HTML)
 /coverage/


### PR DESCRIPTION
That way debugging the styles in REX is easier because the original LESS/SASS files will be in the browser dev tools instead of the compiled CSS file.

Alternatively, is there a command that enki could run to build the CSS file? Then the CSS file (& source map) would not need to be committed to the repo at all

cc @TylerZeroMaster 