### PR TITLE
Update scaled line heights

### DIFF
--- a/styles/designs/webview/parts/_caption-components.scss
+++ b/styles/designs/webview/parts/_caption-components.scss
@@ -64,7 +64,7 @@ $Caption__Container--Table: (
     border-top-width: 0.1rem,
     border-top-style: solid,
     border-top-color: enum('ValueSet:::REQUIRED'),
-    font-size: scaled_size(0.9em),
+    font-size: 0.9em,
   )
 );
 

--- a/styles/designs/webview/parts/_titles-components.scss
+++ b/styles/designs/webview/parts/_titles-components.scss
@@ -20,6 +20,7 @@ $H2: (
   _properties: (
     color: enum('ValueSet:::REQUIRED'),
     font-size: scaled_size(3.2rem),
+    line-height: scaled_size(4rem),
     margin: '1.5rem 0 1rem 0',
     font-weight: bold,
   )
@@ -60,6 +61,7 @@ $H3: (
   _properties: (
     color: enum('ValueSet:::REQUIRED'),
     font-size: scaled_size(2.4rem),
+    line-height: scaled_size(3rem),
     margin: '1.5rem 0 1rem 0',
     font-weight: bold,
   )

--- a/styles/output/webview-generic.css
+++ b/styles/output/webview-generic.css
@@ -50,12 +50,14 @@ h1 {
 h2 {
   color: #333;
   font-size: calc(3.2rem * var(--content-text-scale));
+  line-height: calc(4rem * var(--content-text-scale));
   margin: 1.5rem 0 1rem 0;
   font-weight: bold; }
 
 h3 {
   color: #333;
   font-size: calc(2.4rem * var(--content-text-scale));
+  line-height: calc(3rem * var(--content-text-scale));
   margin: 1.5rem 0 1rem 0;
   font-weight: bold; }
 
@@ -1516,7 +1518,7 @@ a:hover {
   border-top-width: 0.1rem;
   border-top-style: solid;
   border-top-color: #dcdcdc;
-  font-size: calc(0.9em * var(--content-text-scale)); }
+  font-size: 0.9em; }
 
 .os-table .os-caption-container > .os-title-label {
   display: inline-block;


### PR DESCRIPTION
Adds a default line-height for h2 and h3 to prevent wrapped text from appearing vertically squished:

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/34174/171948408-7c8d1c69-de4a-4b68-a7c2-adc638ed067b.png) | ![image](https://user-images.githubusercontent.com/34174/171948309-0be61a61-d609-46b5-97b3-ef9043e833a8.png)

Also fixes a bug with accidentally scaling an `em`.